### PR TITLE
Log verbose information to debug

### DIFF
--- a/pypsrp/client.py
+++ b/pypsrp/client.py
@@ -157,10 +157,10 @@ class Client(object):
                               ["-NoProfile", "-NonInteractive",
                                "-EncodedCommand", encoded_command])
             process.begin_invoke()
-            log.info("Starting to send file data to remote process")
+            log.debug("Starting to send file data to remote process")
             for input_data, end in read_gen:
                 process.send(input_data, end)
-            log.info("Finished sending file data to remote process")
+            log.debug("Finished sending file data to remote process")
             process.end_invoke()
 
         stderr = self.sanitise_clixml(process.stderr)
@@ -297,9 +297,9 @@ $hash.Replace("-", "").ToLowerInvariant()''' % src
         with RunspacePool(self.wsman) as pool:
             powershell = PowerShell(pool)
             powershell.add_script(script)
-            log.info("Starting remote process to output file data")
+            log.debug("Starting remote process to output file data")
             powershell.invoke()
-            log.info("Finished remote process to output file data")
+            log.debug("Finished remote process to output file data")
 
             if powershell.had_errors:
                 errors = powershell.streams.error

--- a/pypsrp/encryption.py
+++ b/pypsrp/encryption.py
@@ -16,7 +16,7 @@ class WinRMEncryption(object):
     SPNEGO = "application/HTTP-SPNEGO-session-encrypted"
 
     def __init__(self, auth, protocol):
-        log.info("Initialising WinRMEncryption helper for protocol %s"
+        log.debug("Initialising WinRMEncryption helper for protocol %s"
                  % protocol)
         self.auth = auth
         self.protocol = protocol
@@ -29,7 +29,7 @@ class WinRMEncryption(object):
             self._unwrap = self._unwrap_credssp
 
     def wrap_message(self, message, hostname):
-        log.info("Wrapping message for host: %s" % hostname)
+        log.debug("Wrapping message for host: %s" % hostname)
         if self.protocol == self.CREDSSP and len(message) > self.SIXTEEN_KB:
             content_type = "multipart/x-multi-encrypted"
             encrypted_msg = b""
@@ -48,7 +48,7 @@ class WinRMEncryption(object):
         return content_type, encrypted_msg
 
     def unwrap_message(self, message, hostname):
-        log.info("Unwrapped message for host: %s" % hostname)
+        log.debug("Unwrapped message for host: %s" % hostname)
         parts = message.split(to_bytes("%s\r\n" % self.MIME_BOUNDARY))
         parts = list(filter(None, parts))
 

--- a/pypsrp/encryption.py
+++ b/pypsrp/encryption.py
@@ -17,7 +17,7 @@ class WinRMEncryption(object):
 
     def __init__(self, auth, protocol):
         log.debug("Initialising WinRMEncryption helper for protocol %s"
-                 % protocol)
+                  % protocol)
         self.auth = auth
         self.protocol = protocol
 

--- a/pypsrp/messages.py
+++ b/pypsrp/messages.py
@@ -116,7 +116,7 @@ class Message(object):
         if not isinstance(message_data, binary_type):
             message_data = \
                 ET.tostring(message_data, encoding='utf-8', method='xml')
-        log.info("Packing PSRP message: %s" % to_string(message_data))
+        log.debug("Packing PSRP message: %s" % to_string(message_data))
 
         data = struct.pack("<I", self.destination)
         data += struct.pack("<I", self.message_type)
@@ -139,8 +139,8 @@ class Message(object):
         else:
             message_data = to_string(data[40:])
 
-        log.info("Unpacking PSRP message of type %d: %s"
-                 % (message_type, message_data))
+        log.debug("Unpacking PSRP message of type %d: %s"
+                  % (message_type, message_data))
 
         message_obj = {
             MessageType.SESSION_CAPABILITY: SessionCapability,

--- a/pypsrp/powershell.py
+++ b/pypsrp/powershell.py
@@ -74,8 +74,8 @@ class RunspacePool(object):
         :param session_key_timeout_ms: The maximum time to wait for a session
             key transfer from the server
         """
-        log.debug("Initialising RunspacePool object for configuration %s"
-                  % configuration_name)
+        log.info("Initialising RunspacePool object for configuration %s"
+                 % configuration_name)
         # The below are defined in some way at
         # https://msdn.microsoft.com/en-us/library/ee176015.aspx
         self.id = str(uuid.uuid4()).upper()
@@ -131,7 +131,7 @@ class RunspacePool(object):
 
         :param min_runspaces: The minimum number of runspaces in the pool
         """
-        log.debug("Setting minimum runspaces for pool to %d" % min_runspaces)
+        log.info("Setting minimum runspaces for pool to %d" % min_runspaces)
         if self.state != RunspacePoolState.OPENED:
             self._min_runspaces = min_runspaces
             return
@@ -169,7 +169,7 @@ class RunspacePool(object):
 
         :param max_runspaces: The maximum number of runspaces in the pool
         """
-        log.debug("Setting maximum runspaces for pool to %d" % max_runspaces)
+        log.info("Setting maximum runspaces for pool to %d" % max_runspaces)
         if self.state != RunspacePoolState.OPENED:
             self._max_runspaces = max_runspaces
             return
@@ -208,7 +208,7 @@ class RunspacePool(object):
         operations waiting for a runspace. If the pool is already closed or
         broken or closing, this will just return
         """
-        log.debug("Closing Runspace Pool")
+        log.info("Closing Runspace Pool")
         if self.state in [RunspacePoolState.CLOSED, RunspacePoolState.CLOSING,
                           RunspacePoolState.BROKEN]:
             return
@@ -222,7 +222,7 @@ class RunspacePool(object):
         state. This only supports reconnecting to a runspace pool created by
         the same client with the same SessionId value in the WSMan headers.
         """
-        log.debug("Connecting to Runspace Pool")
+        log.info("Connecting to Runspace Pool")
         if self.state == RunspacePoolState.OPENED:
             return
         elif self.state != RunspacePoolState.DISCONNECTED:
@@ -290,8 +290,8 @@ class RunspacePool(object):
 
         :return: List<PowerShell>: List of disconnected PowerShell objects
         """
-        log.debug("Getting list of disconnected PowerShells for the current "
-                  "Runspace Pool")
+        log.info("Getting list of disconnected PowerShells for the current "
+                 "Runspace Pool")
         return [s for s in self.pipelines.values() if
                 s.state == PSInvocationState.DISCONNECTED]
 
@@ -299,7 +299,7 @@ class RunspacePool(object):
         """
         Disconnects the runspace pool, must be in the Opened state
         """
-        log.debug("Disconnecting from Runspace Pool")
+        log.info("Disconnecting from Runspace Pool")
         if self.state == RunspacePoolState.DISCONNECTED:
             return
         elif self.state != RunspacePoolState.OPENED:
@@ -407,7 +407,7 @@ class RunspacePool(object):
             pypsrp.wsman.WSMan is supported.
         :return: List<RunspacePool> objects each in the Disconnected state
         """
-        log.debug("Getting list of Runspace Pools on remote host")
+        log.info("Getting list of Runspace Pools on remote host")
         wsen = NAMESPACES['wsen']
         wsmn = NAMESPACES['wsman']
 
@@ -474,7 +474,7 @@ class RunspacePool(object):
             runspace host. These can then be accessed in a PowerShell instance
             of the runspace with $PSSenderInfo.ApplicationArguments
         """
-        log.debug("Openning a new Runspace Pool on remote host")
+        log.info("Openning a new Runspace Pool on remote host")
         if self.state == RunspacePoolState.OPENED:
             return
         if self.state != RunspacePoolState.BEFORE_OPEN:
@@ -517,7 +517,7 @@ class RunspacePool(object):
         open and if the key has already been exchanged then nothing will
         happen.
         """
-        log.debug("Starting key exchange with remote host")
+        log.info("Starting key exchange with remote host")
         if self._key_exchanged or self._exchange_key is not None:
             # key is already exchanged or we are still in the processes of
             # exchanging it, no need to run again
@@ -562,7 +562,7 @@ class RunspacePool(object):
         This is only supported for the protocol version 2.3 and above (Server
         2016/Windows 10+)
         """
-        log.debug("Resetting remote Runspace Pool state")
+        log.info("Resetting remote Runspace Pool state")
         if self.state == RunspacePoolState.BEFORE_OPEN:
             # no need to reset if the runspace has not been opened
             return
@@ -791,7 +791,7 @@ class PowerShell(object):
         :param runspace_pool: The RunspacePool that the PowerShell instance
             will run over
         """
-        log.debug("Initialising PowerShell in remote Runspace Pool")
+        log.info("Initialising PowerShell in remote Runspace Pool")
         self.runspace_pool = runspace_pool
         self.state = PSInvocationState.NOT_STARTED
 
@@ -1000,7 +1000,7 @@ class PowerShell(object):
             the various steams, see complex_objects.RemoteStreamOptions for the
             values. Will default to returning the invocation info on all
         """
-        log.debug("Beginning remote Pipeline invocation")
+        log.info("Beginning remote Pipeline invocation")
         if self.state != PSInvocationState.NOT_STARTED:
             raise InvalidPipelineStateError(
                 self.state, PSInvocationState.NOT_STARTED,
@@ -1030,7 +1030,7 @@ class PowerShell(object):
 
         # finally send the input if any was specified
         if input is not None:
-            log.debug("Sending input to remote Pipeline")
+            log.info("Sending input to remote Pipeline")
             if not isinstance(input, list):
                 input = [input]
 
@@ -1244,7 +1244,7 @@ class PowerShell(object):
         """
         Stop the currently running command.
         """
-        log.debug("Stopping remote Pipeline")
+        log.info("Stopping remote Pipeline")
         if self.state in [PSInvocationState.STOPPING,
                           PSInvocationState.STOPPED]:
             return

--- a/pypsrp/powershell.py
+++ b/pypsrp/powershell.py
@@ -74,8 +74,8 @@ class RunspacePool(object):
         :param session_key_timeout_ms: The maximum time to wait for a session
             key transfer from the server
         """
-        log.info("Initialising RunspacePool object for configuration %s"
-                 % configuration_name)
+        log.debug("Initialising RunspacePool object for configuration %s"
+                  % configuration_name)
         # The below are defined in some way at
         # https://msdn.microsoft.com/en-us/library/ee176015.aspx
         self.id = str(uuid.uuid4()).upper()
@@ -131,7 +131,7 @@ class RunspacePool(object):
 
         :param min_runspaces: The minimum number of runspaces in the pool
         """
-        log.info("Setting minimum runspaces for pool to %d" % min_runspaces)
+        log.debug("Setting minimum runspaces for pool to %d" % min_runspaces)
         if self.state != RunspacePoolState.OPENED:
             self._min_runspaces = min_runspaces
             return
@@ -169,7 +169,7 @@ class RunspacePool(object):
 
         :param max_runspaces: The maximum number of runspaces in the pool
         """
-        log.info("Setting maximum runspaces for pool to %d" % max_runspaces)
+        log.debug("Setting maximum runspaces for pool to %d" % max_runspaces)
         if self.state != RunspacePoolState.OPENED:
             self._max_runspaces = max_runspaces
             return
@@ -208,7 +208,7 @@ class RunspacePool(object):
         operations waiting for a runspace. If the pool is already closed or
         broken or closing, this will just return
         """
-        log.info("Closing Runspace Pool")
+        log.debug("Closing Runspace Pool")
         if self.state in [RunspacePoolState.CLOSED, RunspacePoolState.CLOSING,
                           RunspacePoolState.BROKEN]:
             return
@@ -222,7 +222,7 @@ class RunspacePool(object):
         state. This only supports reconnecting to a runspace pool created by
         the same client with the same SessionId value in the WSMan headers.
         """
-        log.info("Connecting to Runspace Pool")
+        log.debug("Connecting to Runspace Pool")
         if self.state == RunspacePoolState.OPENED:
             return
         elif self.state != RunspacePoolState.DISCONNECTED:
@@ -290,8 +290,8 @@ class RunspacePool(object):
 
         :return: List<PowerShell>: List of disconnected PowerShell objects
         """
-        log.info("Getting list of disconnected PowerShells for the current "
-                 "Runspace Pool")
+        log.debug("Getting list of disconnected PowerShells for the current "
+                  "Runspace Pool")
         return [s for s in self.pipelines.values() if
                 s.state == PSInvocationState.DISCONNECTED]
 
@@ -299,7 +299,7 @@ class RunspacePool(object):
         """
         Disconnects the runspace pool, must be in the Opened state
         """
-        log.info("Disconnecting from Runspace Pool")
+        log.debug("Disconnecting from Runspace Pool")
         if self.state == RunspacePoolState.DISCONNECTED:
             return
         elif self.state != RunspacePoolState.OPENED:
@@ -407,7 +407,7 @@ class RunspacePool(object):
             pypsrp.wsman.WSMan is supported.
         :return: List<RunspacePool> objects each in the Disconnected state
         """
-        log.info("Getting list of Runspace Pools on remote host")
+        log.debug("Getting list of Runspace Pools on remote host")
         wsen = NAMESPACES['wsen']
         wsmn = NAMESPACES['wsman']
 
@@ -474,7 +474,7 @@ class RunspacePool(object):
             runspace host. These can then be accessed in a PowerShell instance
             of the runspace with $PSSenderInfo.ApplicationArguments
         """
-        log.info("Openning a new Runspace Pool on remote host")
+        log.debug("Openning a new Runspace Pool on remote host")
         if self.state == RunspacePoolState.OPENED:
             return
         if self.state != RunspacePoolState.BEFORE_OPEN:
@@ -517,7 +517,7 @@ class RunspacePool(object):
         open and if the key has already been exchanged then nothing will
         happen.
         """
-        log.info("Starting key exchange with remote host")
+        log.debug("Starting key exchange with remote host")
         if self._key_exchanged or self._exchange_key is not None:
             # key is already exchanged or we are still in the processes of
             # exchanging it, no need to run again
@@ -562,7 +562,7 @@ class RunspacePool(object):
         This is only supported for the protocol version 2.3 and above (Server
         2016/Windows 10+)
         """
-        log.info("Resetting remote Runspace Pool state")
+        log.debug("Resetting remote Runspace Pool state")
         if self.state == RunspacePoolState.BEFORE_OPEN:
             # no need to reset if the runspace has not been opened
             return
@@ -791,7 +791,7 @@ class PowerShell(object):
         :param runspace_pool: The RunspacePool that the PowerShell instance
             will run over
         """
-        log.info("Initialising PowerShell in remote Runspace Pool")
+        log.debug("Initialising PowerShell in remote Runspace Pool")
         self.runspace_pool = runspace_pool
         self.state = PSInvocationState.NOT_STARTED
 
@@ -1000,7 +1000,7 @@ class PowerShell(object):
             the various steams, see complex_objects.RemoteStreamOptions for the
             values. Will default to returning the invocation info on all
         """
-        log.info("Beginning remote Pipeline invocation")
+        log.debug("Beginning remote Pipeline invocation")
         if self.state != PSInvocationState.NOT_STARTED:
             raise InvalidPipelineStateError(
                 self.state, PSInvocationState.NOT_STARTED,
@@ -1030,7 +1030,7 @@ class PowerShell(object):
 
         # finally send the input if any was specified
         if input is not None:
-            log.info("Sending input to remote Pipeline")
+            log.debug("Sending input to remote Pipeline")
             if not isinstance(input, list):
                 input = [input]
 
@@ -1244,7 +1244,7 @@ class PowerShell(object):
         """
         Stop the currently running command.
         """
-        log.info("Stopping remote Pipeline")
+        log.debug("Stopping remote Pipeline")
         if self.state in [PSInvocationState.STOPPING,
                           PSInvocationState.STOPPED]:
             return

--- a/pypsrp/shell.py
+++ b/pypsrp/shell.py
@@ -353,8 +353,8 @@ class Process(object):
             bypass it. If True then executable must be the full path to the
             exe. This only works on older OS's before 2012 R2 (not including)
         """
-        log.info("Creating WinRS process for '%s' with arguments '%s'"
-                 % (executable, arguments))
+        log.debug("Creating WinRS process for '%s' with arguments '%s'"
+                  % (executable, arguments))
         self.shell = shell
         self.id = id
         self.no_shell = no_shell

--- a/pypsrp/spgnego.py
+++ b/pypsrp/spgnego.py
@@ -83,17 +83,17 @@ def get_auth_context(username, password, auth_provider, cbt_app_data,
 
     if HAS_SSPI:
         # always use SSPI when available
-        log.info("SSPI is available and will be used as the auth backend")
+        log.debug("SSPI is available and will be used as the auth backend")
         context = SSPIContext(username, password, auth_provider, cbt_app_data,
                               hostname, service, delegate)
     elif HAS_GSSAPI and auth_provider != "ntlm":
-        log.info("GSSAPI is available, determine if it can handle the auth "
-                 "provider specified or whether the NTLM fallback is used")
+        log.debug("GSSAPI is available, determine if it can handle the auth "
+                  "provider specified or whether the NTLM fallback is used")
         mechs_available = GSSAPIContext.get_available_mechs(wrap_required)
 
         if auth_provider in mechs_available:
-            log.info("GSSAPI with mech %s is being used as the auth backend"
-                     % auth_provider)
+            log.debug("GSSAPI with mech %s is being used as the auth backend"
+                      % auth_provider)
             context = GSSAPIContext(username, password, auth_provider,
                                     cbt_app_data, hostname, service, delegate,
                                     wrap_required)
@@ -104,9 +104,9 @@ def get_auth_context(username, password, auth_provider, cbt_app_data,
                              "disable encryption, use https or specify "
                              "auto/ntlm")
         elif auth_provider == "auto" and "kerberos" in mechs_available:
-            log.info("GSSAPI is available but SPNEGO/NTLM is not natively "
-                     "supported, try to use Kerberos explicitly and fallback "
-                     "to NTLM with ntlm-auth if that fails")
+            log.debug("GSSAPI is available but SPNEGO/NTLM is not natively "
+                      "supported, try to use Kerberos explicitly and fallback "
+                      "to NTLM with ntlm-auth if that fails")
             # we can't rely on SPNEGO in GSSAPI as NTLM is not available, try
             # and initialise a kerb context and get the first token. If that
             # fails, fallback to NTLM with ntlm-auth
@@ -118,8 +118,8 @@ def get_auth_context(username, password, auth_provider, cbt_app_data,
                 context.init_context()
                 context_gen = context.step()
                 out_token = next(context_gen)
-                log.info("GSSAPI with mech kerberos is being used as the auth "
-                         "backend")
+                log.debug("GSSAPI with mech kerberos is being used as the auth "
+                          "backend")
             except gssapi.exceptions.GSSError as err:
                 log.warning("Failed to initialise a GSSAPI context, failling "
                             "back to NTLM: %s" % str(err))
@@ -127,8 +127,8 @@ def get_auth_context(username, password, auth_provider, cbt_app_data,
                 out_token = None
                 context = NTLMContext(username, password, cbt_app_data)
         else:
-            log.info("GSSAPI is available but does not support NTLM or "
-                     "Kerberos with encryption, fallback to ntlm-auth")
+            log.debug("GSSAPI is available but does not support NTLM or "
+                      "Kerberos with encryption, fallback to ntlm-auth")
             context = NTLMContext(username, password, cbt_app_data)
     else:
         if auth_provider not in ["auto", "ntlm"]:
@@ -136,8 +136,8 @@ def get_auth_context(username, password, auth_provider, cbt_app_data,
                              "without GSSAPI or SSPI being installed, select "
                              "auto or install GSSAPI or SSPI"
                              % auth_provider)
-        log.info("SSPI or GSSAPI is not available, using ntlm-auth as the "
-                 "auth backend")
+        log.debug("SSPI or GSSAPI is not available, using ntlm-auth as the "
+                  "auth backend")
         context = NTLMContext(username, password, cbt_app_data)
 
     if context_gen is None:
@@ -372,7 +372,7 @@ class GSSAPIContext(AuthContext):
     def step(self):
         in_token = None
         while not self._context.complete:
-            log.info("GSSAPI: Calling gss_init_sec_context()")
+            log.debug("GSSAPI: Calling gss_init_sec_context()")
             out_token = self._context.step(in_token)
             in_token = yield out_token
 
@@ -521,8 +521,8 @@ class NTLMContext(AuthContext):
         log.debug("NTLM Negotiate message: %s" % binascii.hexlify(msg1))
 
         msg2 = yield msg1
-        log.info("NTLM: Parsing Challenge message and generating "
-                 "Authenticate message: %s" % binascii.hexlify(msg2))
+        log.debug("NTLM: Parsing Challenge message and generating "
+                  "Authenticate message: %s" % binascii.hexlify(msg2))
         msg3 = self._context.step(msg2)
 
         yield msg3

--- a/pypsrp/spgnego.py
+++ b/pypsrp/spgnego.py
@@ -118,8 +118,8 @@ def get_auth_context(username, password, auth_provider, cbt_app_data,
                 context.init_context()
                 context_gen = context.step()
                 out_token = next(context_gen)
-                log.debug("GSSAPI with mech kerberos is being used as the auth "
-                          "backend")
+                log.debug("GSSAPI with mech kerberos is being used as the "
+                          "auth backend")
             except gssapi.exceptions.GSSError as err:
                 log.warning("Failed to initialise a GSSAPI context, failling "
                             "back to NTLM: %s" % str(err))

--- a/pypsrp/wsman.py
+++ b/pypsrp/wsman.py
@@ -202,9 +202,9 @@ class WSMan(object):
             negotiate_service: Override the service used when building the
                 server SPN, default='WSMAN'
         """
-        log.info("Initialising WSMan class with maximum envelope size of %d "
-                 "and operation timeout of %s"
-                 % (max_envelope_size, operation_timeout))
+        log.debug("Initialising WSMan class with maximum envelope size of %d "
+                  "and operation timeout of %s"
+                  % (max_envelope_size, operation_timeout))
         self.session_id = str(uuid.uuid4())
         self.locale = locale
         self.data_locale = data_locale
@@ -318,7 +318,7 @@ class WSMan(object):
 
     def get_server_config(self, uri="config"):
         resource_uri = "http://schemas.microsoft.com/wbem/wsman/1/%s" % uri
-        log.info("Getting server config with URI %s" % resource_uri)
+        log.debug("Getting server config with URI %s" % resource_uri)
         return self.get(resource_uri)
 
     def update_max_payload_size(self, max_payload_size=None):
@@ -688,8 +688,8 @@ class _TransportHTTP(object):
 
         self.endpoint = "%s://%s:%d/%s" \
                         % ("https" if ssl else "http", server, self.port, path)
-        log.info("Initialising HTTP transport for endpoint: %s, auth: %s, "
-                 "user: %s" % (self.endpoint, self.username, self.auth))
+        log.debug("Initialising HTTP transport for endpoint: %s, auth: %s, "
+                  "user: %s" % (self.endpoint, self.username, self.auth))
         self.session = None
 
         # used when building tests, keep commented out

--- a/pypsrp/wsman.py
+++ b/pypsrp/wsman.py
@@ -379,8 +379,8 @@ class WSMan(object):
                 raise self._parse_wsman_fault(err.response_text)
             except ET.ParseError:
                 # no XML message is present so not a WSManFault error
-                log.warning("Failed to parse WSManFault message on WinRM error"
-                            " response, raising original WinRMTransportError")
+                log.error("Failed to parse WSManFault message on WinRM error"
+                          " response, raising original WinRMTransportError")
                 raise err
 
         response_xml = ET.fromstring(response)


### PR DESCRIPTION
Currently, too much information is being logged as "informational", that really is debug information.

Since informational messages go into the default Ansible log, the log becomes useless of the sheer volume of transaction information or low-level stuff.

I made the arbitrary decision here to keep "info" for most basic client actions, but not for low-level/technical output, that in normal usage should not be needed.