### PR TITLE
Ci fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,11 @@ matrix:
   - python: 3.7
   - python: 3.8-dev
 
+  # 3.8 is still an alpha and I'm running it to see if anything breaks but
+  # don't want it to stop the build
+  allow_failures:
+  - python: 3.8-dev
+
 before_install:
 # install gss-ntlmssp required for tests
 - sudo ./build-scripts/install_gssntlmssp.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,19 +3,21 @@ language: python
 # required to install gss-ntlmssp
 sudo: true
 
-python:
-- 2.6
-- 2.7
-- 3.4
-- 3.5
-- 3.6
+# Most Python's support Xenial now, except 2.6, 3.4, and 3.5
+dist: xenial
 
-# Python 3.7 requires 16.04 (Xenial), this is a hack to get that specific
-# distro running that version until I can swap the rest over officially
 matrix:
   include:
+  - python: 2.6
+    dist: trusty
+  - python: 2.7
+  - python: 3.4
+    dist: trusty
+  - python: 3.5
+    dist: trusty
+  - python: 3.6
   - python: 3.7
-    dist: xenial
+  - python: 3.8-dev
 
 before_install:
 # install gss-ntlmssp required for tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.3.1 - TBD
 
 * Fix issue where `negotiate_delegate=True` did nothing with `pywin32` on Windows
+* Fix instances of invalid escape sequences in strings that will break in future Python versions - https://bugs.python.org/issue27364 
 
 
 ## 0.3.0 - 2018-11-14

--- a/pypsrp/encryption.py
+++ b/pypsrp/encryption.py
@@ -133,7 +133,7 @@ class WinRMEncryption(object):
         log.debug("Attempting to get CredSSP trailer length for msg of "
                   "length %d with cipher %s" % (msg_len, cipher_suite))
 
-        if re.match('^.*-GCM-[\w\d]*$', cipher_suite):
+        if re.match(r'^.*-GCM-[\w\d]*$', cipher_suite):
             # GCM has a fixed length of 16 bytes
             trailer_length = 16
         else:

--- a/pypsrp/negotiate.py
+++ b/pypsrp/negotiate.py
@@ -72,7 +72,7 @@ class HTTPNegotiateAuth(AuthBase):
         self.wrap_required = wrap_required
         self.contexts = {}
 
-        self._regex = re.compile('Negotiate\s*([^,]*),?', re.I)
+        self._regex = re.compile(r'Negotiate\s*([^,]*),?', re.I)
 
     def __call__(self, request):
         request.headers['Connection'] = 'Keep-Alive'

--- a/pypsrp/serializer.py
+++ b/pypsrp/serializer.py
@@ -67,7 +67,7 @@ class Serializer(object):
         # to support surrogate UTF-16 pairs we need to use a UTF-16 regex
         # so we can replace the UTF-16 string representation with the actual
         # UTF-16 byte value and then decode that
-        self._deserial_str = re.compile(b"\\x00_\\x00x([\0\w]{8})\\x00_")
+        self._deserial_str = re.compile(b"\\x00_\\x00x([\\0\\w]{8})\\x00_")
 
     def serialize(self, value, metadata=None, parent=None, clear=True):
         """

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,11 +1,14 @@
 gssapi>=1.5.0; sys_platform != 'win32'
+idna<2.8; python_version<"2.7"
+lxml<4.3.0; python_version<"2.7"
 mock; python_version<"3.0"
 ordereddict; python_version<"2.7"
-#pytest<=3.2.5
-pytest
+pytest==3.2.5; python_version<"2.7"
+pytest>=3.6; python_version>"2.7"
 pytest-cov
 pytest-pep8
 pytest-instafail
 pyyaml
 requests-credssp>=1.0.0
 pycparser<=2.18; python_version<"2.7"
+xmldiff

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,7 +1,8 @@
 gssapi>=1.5.0; sys_platform != 'win32'
 mock; python_version<"3.0"
 ordereddict; python_version<"2.7"
-pytest<=3.2.5
+#pytest<=3.2.5
+pytest
 pytest-cov
 pytest-pep8
 pytest-instafail

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,4 +5,5 @@ universal = 1
 license_file = LICENSE
 
 [tool:pytest]
+pep8maxlinelength = 119
 pep8ignore = tests/*.py E501

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
     long_description=long_description,
     keywords='winrm psrp winrs windows',
     license='MIT',
+    python_requires='>=2.6,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
     classifiers=[
         'Development Status :: 4 - Beta',
         'License :: OSI Approved :: MIT License',

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     ],
     extras_require={
         ':python_version<"2.7"': [
-            'lxml',
+            'lxml<4.3.0',  # 4.3.0+ has dropped support for Python 2.6
         ],
         'credssp': [
             'requests-credssp>=1.0.0'

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,18 @@
+import sys
+
+if sys.version_info[0] == 2 and sys.version_info[1] < 7:  # pragma: no cover
+    # xmldiff is not compatible with Python 2.6. We just need to rely on a
+    # simple string difference
+    xml_diff = None
+else:  # pragma: no cover
+    from xmldiff import main as xml_diff
+
+
+def assert_xml_diff(actual, expected, msg=None):
+    # Only use xmldiff if it has been imported and both the xml messages
+    # contain data
+    if xml_diff and actual and expected:
+        diff = xml_diff.diff_texts(actual, expected)
+        assert len(diff) == 0, msg
+    else:
+        assert actual == expected, msg

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -220,7 +220,7 @@ class TransportFake(object):
         element.text = base64.b64encode(new_value).decode('utf-8')
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='function')
 def wsman_conn(request, monkeypatch):
     test_params = request.param
     if not isinstance(test_params, list) or len(test_params) != 2:

--- a/tests/test_complex_objects.py
+++ b/tests/test_complex_objects.py
@@ -2,6 +2,8 @@ import sys
 
 import pytest
 
+from . import assert_xml_diff
+
 from pypsrp.complex_objects import Array, BufferCell, BufferCellType, Color, \
     Command, CommandParameter, CommandType, Coordinates, HostInfo, \
     ObjectMeta, Pipeline, PipelineResultTypes, PSThreadOptions, \
@@ -209,7 +211,7 @@ class TestHostInfo(object):
 
         actual = serializer.serialize(host_info)
         actual_xml = normalise_xml(ET.tostring(actual))
-        assert expected_xml == actual_xml
+        assert_xml_diff(actual_xml, expected_xml)
 
 
 class TestRemoteStreamOptions(object):
@@ -593,7 +595,7 @@ class TestPipeline(object):
 
         actual = serializer.serialize(pipeline)
         actual_xml = normalise_xml(ET.tostring(actual))
-        assert expected_xml == actual_xml
+        assert_xml_diff(actual_xml, expected_xml)
 
     def test_create_pipeline_multiple(self):
         serializer = Serializer()
@@ -629,7 +631,7 @@ class TestPipeline(object):
 
         actual = serializer.serialize(pipeline)
         actual_xml = normalise_xml(ET.tostring(actual))
-        assert expected_xml == actual_xml
+        assert_xml_diff(actual_xml, expected_xml)
 
     def test_parse_pipeline_single(self):
         serializer = Serializer()
@@ -803,7 +805,7 @@ class TestBufferCell(object):
         actual = serializer.serialize(buffer_cell)
         actual_xml = normalise_xml(ET.tostring(actual))
 
-        assert expected_xml == actual_xml
+        assert_xml_diff(actual_xml, expected_xml)
 
     def test_parse_buffer_cell(self):
         serializer = Serializer()
@@ -949,14 +951,14 @@ class TestArray(object):
         actual = serializer.serialize(array)
         actual_xml = normalise_xml(ET.tostring(actual))
 
-        assert expected_xml == actual_xml
+        assert_xml_diff(actual_xml, expected_xml)
 
         array.array = [4, 5, 6]
         expected_xml = normalise_xml(self.SINGLE_ARRAY2)
         actual = serializer.serialize(array)
         actual_xml = normalise_xml(ET.tostring(actual))
 
-        assert expected_xml == actual_xml
+        assert_xml_diff(actual_xml, expected_xml)
 
     def test_parse_array(self):
         serializer = Serializer()
@@ -976,7 +978,7 @@ class TestArray(object):
         actual = serializer.serialize(array)
         actual_xml = normalise_xml(ET.tostring(actual))
 
-        assert expected_xml == actual_xml
+        assert_xml_diff(actual_xml, expected_xml)
 
     def test_parse_two_dimensional_array(self):
         serializer = Serializer()
@@ -999,7 +1001,7 @@ class TestArray(object):
         actual = serializer.serialize(array)
         actual_xml = normalise_xml(ET.tostring(actual))
 
-        assert expected_xml == actual_xml
+        assert_xml_diff(actual_xml, expected_xml)
 
     def test_parse_three_dimensional_array(self):
         serializer = Serializer()

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -3,6 +3,8 @@ import uuid
 
 import pytest
 
+from . import assert_xml_diff
+
 from pypsrp.complex_objects import ComplexObject, GenericComplexObject, \
     ListMeta, ObjectMeta, StackMeta
 from pypsrp.exceptions import SerializationError
@@ -336,7 +338,7 @@ class TestSerializer(object):
             '<Nil N="SecurityIdentifierString" /></Props></Obj>'
         actual = serializer.serialize(obj)
         actual_xml = to_string(ET.tostring(actual))
-        assert actual_xml == expected
+        assert_xml_diff(actual_xml, expected)
 
     def test_deserialize_circular_reference(self):
         serializer = Serializer()

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -106,7 +106,7 @@ class TestWinRS(object):
     @pytest.mark.parametrize('wsman_conn',
                              [[True, 'test_winrs_environment']], indirect=True)
     def test_winrs_environment(self, wsman_conn):
-        complex_chars = '_-(){}[]<>*+-/\?"''!@#$^&|;:i,.`~0'
+        complex_chars = r'_-(){}[]<>*+-/\?"''!@#$^&|;:i,.`~0'
         env_block = OrderedDict([
             ('env1', 'var1'),
             (1234, 5678),

--- a/tests/test_wsman.py
+++ b/tests/test_wsman.py
@@ -389,7 +389,7 @@ class TestWSMan(object):
         assert exc.value.reason is None
 
     def test_raise_wsman_fault_with_wsman_fault(self):
-        xml_text = '''
+        xml_text = r'''
         <s:Envelope xml:lang="en-US" xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:x="http://schemas.xmlsoap.org/ws/2004/09/transfer" xmlns:e="http://schemas.xmlsoap.org/ws/2004/08/eventing" xmlns:n="http://schemas.xmlsoap.org/ws/2004/09/enumeration" xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd" xmlns:p="http://schemas.microsoft.com/wbem/wsman/1/wsman.xsd">
             <s:Header>
                 <a:Action>http://schemas.dmtf.org/wbem/wsman/1/wsman/fault</a:Action>
@@ -434,7 +434,7 @@ class TestWSMan(object):
         assert exc.value.reason == "The parameter is incorrect."
 
     def test_raise_wsman_fault_without_provider(self):
-        xml_text = '''
+        xml_text = r'''
         <s:Envelope xml:lang="en-US" xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:x="http://schemas.xmlsoap.org/ws/2004/09/transfer" xmlns:e="http://schemas.xmlsoap.org/ws/2004/08/eventing" xmlns:n="http://schemas.xmlsoap.org/ws/2004/09/enumeration" xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd" xmlns:p="http://schemas.microsoft.com/wbem/wsman/1/wsman.xsd">
             <s:Header>
                 <a:Action>http://schemas.dmtf.org/wbem/wsman/1/wsman/fault</a:Action>
@@ -535,7 +535,7 @@ class TestOptionSet(object):
         assert actual.tag == \
             "{http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd}OptionSet"
         assert actual.text is None
-        assert actual.getchildren() == []
+        assert list(actual) == []
         assert str(option_set) == "{}"
 
     def test_set_one_option(self):
@@ -548,7 +548,7 @@ class TestOptionSet(object):
         assert actual.tag == \
             "{http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd}OptionSet"
         assert actual.text is None
-        children = actual.getchildren()
+        children = list(actual)
         assert len(children) == 1
         assert len(children[0].attrib.keys()) == 1
         assert children[0].attrib['Name'] == "key"
@@ -568,7 +568,7 @@ class TestOptionSet(object):
         assert actual.tag == \
             "{http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd}OptionSet"
         assert actual.text is None
-        children = actual.getchildren()
+        children = list(actual)
         assert len(children) == 1
         assert len(children[0].attrib.keys()) == 3
         assert children[0].attrib['Name'] == "key"
@@ -590,7 +590,7 @@ class TestOptionSet(object):
         assert actual.tag == \
             "{http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd}OptionSet"
         assert actual.text is None
-        children = actual.getchildren()
+        children = list(actual)
         assert len(children) == 2
 
         assert len(children[0].attrib.keys()) == 1
@@ -617,7 +617,7 @@ class TestSelectorSet(object):
         assert actual.tag == \
             "{http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd}SelectorSet"
         assert actual.text is None
-        assert actual.getchildren() == []
+        assert list(actual) == []
         assert str(selector_set) == "{}"
 
     def test_set_one_option(self):
@@ -628,7 +628,7 @@ class TestSelectorSet(object):
         assert actual.tag == \
             "{http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd}SelectorSet"
         assert actual.text is None
-        children = actual.getchildren()
+        children = list(actual)
         assert len(children) == 1
         assert len(children[0].attrib.keys()) == 1
         assert children[0].attrib['Name'] == "key"
@@ -646,7 +646,7 @@ class TestSelectorSet(object):
         assert actual.tag == \
             "{http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd}SelectorSet"
         assert actual.text is None
-        children = actual.getchildren()
+        children = list(actual)
         assert len(children) == 1
         assert len(children[0].attrib.keys()) == 3
         assert children[0].attrib['Name'] == "key"
@@ -666,7 +666,7 @@ class TestSelectorSet(object):
         assert actual.tag == \
             "{http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd}SelectorSet"
         assert actual.text is None
-        children = actual.getchildren()
+        children = list(actual)
         assert len(children) == 2
 
         assert len(children[0].attrib.keys()) == 1

--- a/tests/test_wsman.py
+++ b/tests/test_wsman.py
@@ -945,7 +945,8 @@ class TestTransportHTTP(object):
         assert session.headers['User-Agent'] == "Python PSRP Client"
         assert session.trust_env is True
         assert isinstance(session.auth, HTTPNegotiateAuth)
-        assert session.proxies == {}
+        assert 'http' not in session.proxies
+        assert 'https' not in session.proxies
         assert session.verify is True
 
     def test_build_session_cert_validate(self):
@@ -988,7 +989,8 @@ class TestTransportHTTP(object):
     def test_build_session_proxies_default(self):
         transport = _TransportHTTP("server")
         session = transport._build_session()
-        assert session.proxies == {}
+        assert 'http' not in session.proxies
+        assert 'https' not in session.proxies
 
     def test_build_session_proxies_env(self):
         transport = _TransportHTTP("server")
@@ -997,18 +999,21 @@ class TestTransportHTTP(object):
             session = transport._build_session()
         finally:
             del os.environ['https_proxy']
-        assert session.proxies == {"https": "https://envproxy"}
+        assert 'http' not in session.proxies
+        assert session.proxies["https"] == "https://envproxy"
 
     def test_build_session_proxies_kwarg(self):
         transport = _TransportHTTP("server", proxy="https://kwargproxy")
         session = transport._build_session()
-        assert session.proxies == {"https": "https://kwargproxy"}
+        assert 'http' not in session.proxies
+        assert session.proxies["https"] == "https://kwargproxy"
 
     def test_build_session_proxies_kwarg_non_ssl(self):
         transport = _TransportHTTP("server", proxy="http://kwargproxy",
                                    ssl=False)
         session = transport._build_session()
-        assert session.proxies == {"http": "http://kwargproxy"}
+        assert session.proxies["http"] == "http://kwargproxy"
+        assert 'https' not in session.proxies
 
     def test_build_session_proxies_env_kwarg_override(self):
         transport = _TransportHTTP("server", proxy="https://kwargproxy")
@@ -1017,7 +1022,8 @@ class TestTransportHTTP(object):
             session = transport._build_session()
         finally:
             del os.environ['https_proxy']
-        assert session.proxies == {"https": "https://kwargproxy"}
+        assert 'http' not in session.proxies
+        assert session.proxies['https'] == "https://kwargproxy"
 
     def test_build_session_proxies_env_no_proxy_override(self):
         transport = _TransportHTTP("server", no_proxy=True)
@@ -1026,13 +1032,15 @@ class TestTransportHTTP(object):
             session = transport._build_session()
         finally:
             del os.environ['https_proxy']
-        assert session.proxies == {}
+        assert 'http' not in session.proxies
+        assert 'https' not in session.proxies
 
     def test_build_session_proxies_kwarg_ignore_no_proxy(self):
         transport = _TransportHTTP("server", proxy="https://kwargproxy",
                                    no_proxy=True)
         session = transport._build_session()
-        assert session.proxies == {"https": "https://kwargproxy"}
+        assert 'http' not in session.proxies
+        assert session.proxies['https'] == "https://kwargproxy"
 
     def test_send_without_encryption(self, monkeypatch):
         send_mock = MagicMock()


### PR DESCRIPTION
Fix the failing CI build in Travis and also add Python 3.8 testing on the alpha. This also fixes the deprecation warning for invalid escape characters that will start to fail on future Python versions.