### PR TITLE
Fix string serialziation case sensitivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.3.2 - TBD
+
+* Fixed an issue when escaping string in PowerShell that start with `_X`.
+
+
 ## 0.3.1 - 2019-02-26
 
 * Fix issue where `negotiate_delegate=True` did nothing with `pywin32` on Windows

--- a/pypsrp/serializer.py
+++ b/pypsrp/serializer.py
@@ -563,7 +563,7 @@ class Serializer(object):
 
         # The MS-PSRP docs don't state this but the _x0000_ matcher is case insensitive so we need to make sure we
         # escape _X as well as _x.
-        string_value = re.sub(u"_(x)", u"_x005F_\\1", string_value, flags=re.IGNORECASE)
+        string_value = re.sub(u"(?i)_(x)", u"_x005F_\\1", string_value)
         string_value = re.sub(self._serial_str, rplcr, string_value)
 
         return string_value

--- a/pypsrp/serializer.py
+++ b/pypsrp/serializer.py
@@ -560,7 +560,10 @@ class Serializer(object):
         # before running the translation we need to make sure _ before x is
         # encoded, normally _ isn't encoded except when preceding x
         string_value = to_unicode(value)
-        string_value = string_value.replace(u"_x", u"_x005F_x")
+
+        # The MS-PSRP docs don't state this but the _x0000_ matcher is case insensitive so we need to make sure we
+        # escape _X as well as _x.
+        string_value = re.sub(u"_(x)", u"_x005F_\\1", string_value, flags=re.IGNORECASE)
         string_value = re.sub(self._serial_str, rplcr, string_value)
 
         return string_value

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -35,7 +35,9 @@ class TestSerializer(object):
          "actual_x005F_x000A_string_x000A_newline"],
         ["treble clef %s" % b"\xd8\x34\xdd\x1e".decode('utf-16-be'),
          "treble clef _xD834__xDD1E_"],
-        [None, None]
+        [None, None],
+        ["upper_X000a_string\nnewline",
+         "upper_x005F_X000a_string_x000A_newline"],
     ])
     def test_serialize_string(self, input_val, expected):
         serializer = Serializer()


### PR DESCRIPTION
It turns out that PowerShell is running a case insensitive search for escape sequences so sending `_X0000_` would be translated to `\x00\x00`. This changes our serializer to properly escape this.

Fixes https://github.com/jborean93/pypsrp/issues/45