### PR TITLE
Get CI green again on older Python versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,8 @@ before_install:
 - sudo ./build-scripts/install_gssntlmssp.sh
 install:
 - pip install --upgrade pip setuptools
-- pip install -r requirements-test.txt
-- pip install .
+- pip install -r requirements-test.txt -c tests/constraints.txt
+- pip install . -c tests/constraints.txt
 - pip install coveralls
 
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,8 +60,8 @@ install:
     Restart-Service -Name winrm
 - cmd: python -m pip install --upgrade pip
 - cmd: pip install --upgrade setuptools
-- cmd: pip install -r requirements-test.txt
-- cmd: pip install .[credssp]
+- cmd: pip install -r requirements-test.txt -c tests\constraints.txt
+- cmd: pip install .[credssp] -c tests\constraints.txt
 
 # test out pywin32 on some matrixes
 - ps: |

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,7 +1,8 @@
+gssapi<1.6.0; python_version=="2.6"
 gssapi>=1.5.0; sys_platform != 'win32'
 idna<2.8; python_version<"2.7"
 lxml<=4.3.5; python_version=="2.6"
-lxml<=4.3.5; python_version=="3.4"
+lxml<=4.3.0; python_version=="3.4"
 mock; python_version<"3.0"
 ordereddict; python_version<"2.7"
 pytest==3.2.5; python_version<"2.7"

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,7 @@
 gssapi>=1.5.0; sys_platform != 'win32'
 idna<2.8; python_version<"2.7"
-lxml<4.3.0; python_version<"2.7"
+lxml<=4.3.5; python_version=="2.6"
+lxml<=4.3.5; python_version=="3.4"
 mock; python_version<"3.0"
 ordereddict; python_version<"2.7"
 pytest==3.2.5; python_version<"2.7"

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,16 +1,10 @@
-gssapi<1.6.0; python_version=="2.6"
-gssapi>=1.5.0; sys_platform != 'win32'
-idna<2.8; python_version<"2.7"
-lxml<=4.3.5; python_version=="2.6"
-lxml<=4.3.0; python_version=="3.4"
-mock; python_version<"3.0"
-ordereddict; python_version<"2.7"
-pytest==3.2.5; python_version<"2.7"
-pytest>=3.6; python_version>"2.7"
+gssapi >= 1.5.0 ; sys_platform != 'win32'
+mock ; python_version < "3.0"
+ordereddict ; python_version < "2.7"
+pytest
 pytest-cov
 pytest-pep8
 pytest-instafail
 pyyaml
-requests-credssp>=1.0.0
-pycparser<=2.18; python_version<"2.7"
+requests-credssp >= 1.0.0
 xmldiff

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -1,7 +1,7 @@
 # Latest versions supported by Python 2.6
 gssapi < 1.6.0 ; python_version < "2.7"
 idna < 2.8 ; python_version < "2.7"
-lxml <= 4.3.0 ; python_version < "2.7"
+lxml == 4.2.6 ; python_version < "2.7"
 pycparser <= 2.18 ; python_version < "2.7"
 pytest == 3.2.5 ; python_version < "2.7"
 PyYAML == 3.13 ; python_version < "2.7"

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -1,0 +1,12 @@
+# Latest versions supported by Python 2.6
+gssapi < 1.6.0 ; python_version < "2.7"
+idna < 2.8 ; python_version < "2.7"
+lxml <= 4.3.5 ; python_version < "2.7"
+pytest == 3.2.5 ; python_version < "2.7"
+pycparser <= 2.18 ; python_version < "2.7"
+
+# Latest versions supported by Python 3.4
+lxml <= 4.3.0 ; python_version == "3.4"
+
+# Other constraints
+pytest >= 3.6 ; python_version > "2.7"  # Make sure other Python versions use a newer version of pytest

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -2,8 +2,9 @@
 gssapi < 1.6.0 ; python_version < "2.7"
 idna < 2.8 ; python_version < "2.7"
 lxml <= 4.3.5 ; python_version < "2.7"
-pytest == 3.2.5 ; python_version < "2.7"
 pycparser <= 2.18 ; python_version < "2.7"
+pytest == 3.2.5 ; python_version < "2.7"
+PyYAML == 3.13 ; python_version < "2.7"
 
 # Latest versions supported by Python 3.4
 lxml <= 4.3.0 ; python_version == "3.4"

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -1,7 +1,7 @@
 # Latest versions supported by Python 2.6
 gssapi < 1.6.0 ; python_version < "2.7"
 idna < 2.8 ; python_version < "2.7"
-lxml <= 4.3.5 ; python_version < "2.7"
+lxml <= 4.3.0 ; python_version < "2.7"
 pycparser <= 2.18 ; python_version < "2.7"
 pytest == 3.2.5 ; python_version < "2.7"
 PyYAML == 3.13 ; python_version < "2.7"

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,8 @@
 envlist = py26,py27,py34,py35,py36,py37
 
 [testenv]
-deps= -rrequirements-test.txt
-commands=py.test -v --pep8 --cov pypsrp --cov-report term-missing
-passenv=PSRP_*
+deps =
+    -rrequirements-test.txt
+    -ctests/constraints.txt
+commands = py.test -v --pep8 --cov pypsrp --cov-report term-missing
+passenv = PSRP_*


### PR DESCRIPTION
Add a constraints file for better package version management in CI.