### PR TITLE
exposing close function to cleanup requests session

### DIFF
--- a/pypsrp/client.py
+++ b/pypsrp/client.py
@@ -266,6 +266,9 @@ class Client(object):
                 os.close(temp_file)
                 os.remove(path)
 
+    def close(self):
+        self.wsman.close()
+
     @staticmethod
     def sanitise_clixml(clixml):
         """

--- a/pypsrp/wsman.py
+++ b/pypsrp/wsman.py
@@ -510,6 +510,9 @@ class WSMan(object):
 
         return header
 
+    def close(self):
+        self.transport.close()
+
     @staticmethod
     def _parse_wsman_fault(xml_text):
         xml = ET.fromstring(xml_text)
@@ -697,6 +700,9 @@ class _TransportHTTP(object):
 
         # used when building tests, keep commented out
         # self._test_messages = []
+
+    def close(self):
+        self.session.close()
 
     def send(self, message):
         hostname = get_hostname(self.endpoint)


### PR DESCRIPTION
Hi - I use your module for running Windows environment checks in conjunction with the unittest module.

I noticed that when I moved my project over to use python3 I started to get a lot of warnings from the requests lib about unclosed sockets. It looks like other people have come across this too, though not necessarily with `pypsrp`: https://stackoverflow.com/questions/48160728/resourcewarning-unclosed-socket-in-python-3-unit-test

Anyway, I was able to fix my issue with the following code changes, so if you're interested here it is.

Great work by the way with this project!

