### PR TITLE
SerializerV2

### DIFF
--- a/docs/ConvertTo-PythonClass.ps1
+++ b/docs/ConvertTo-PythonClass.ps1
@@ -1,0 +1,252 @@
+# Copyright: (c) 2020, Jordan Borean (@jborean93) <jborean93@gmail.com>
+# MIT License (see LICENSE or https://opensource.org/licenses/MIT)
+
+Function ConvertTo-PythonPrimitiveType {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory=$true)]
+        [AllowNull()]
+        [Type]
+        $InputObject
+    )
+
+    if (-not $InputObject) {
+        return
+    }
+
+    switch ($InputObject.FullName) {
+        System.String { 'PSString' }
+        System.Char { 'PSChar' }
+        System.Boolean { 'PSBool' }
+        System.DateTime { 'PSDateTime' }
+        System.TimeSpan { 'PSDuration' }
+        System.Byte { 'PSByte' }
+        System.SByte { 'PSSbyte' }
+        System.UInt16 { 'PSUInt16' }
+        System.Int16 { 'PSInt16' }
+        System.UInt32 { 'PSUInt' }
+        System.Int32 { 'PSInt' }
+        System.UInt64 { 'PSUInt64' }
+        System.Int64 { 'PSInt64' }
+        System.Single { 'PSSingle' }
+        System.Double { 'PSDouble' }
+        System.Decimal { 'PSDecimal' }
+        System.Byte[] { 'PSByteArray' }
+        System.Guid { 'PSGuid' }
+        System.Uri { 'PSUri' }
+        System.Version { 'PSVersion' }
+        System.Xml.XmlDocument { 'PSXml' }
+        System.Management.Automation.ScriptBlock { 'PSScriptBlock' }
+        System.Security.SecureString { 'PSSecureString' }
+    }
+}
+
+Function ConvertTo-PythonClass {
+    <#
+    .SYNOPSIS
+    Generates Python code to use as a skeleton for a .NET class implemented in Python.
+
+    .PARAMETER InputObject
+    The type or an instance of a type to make the skeleton for.
+
+    .PARAMETER AddDoc
+    Whether to add a Python doc string to the generated skeleton.
+
+    .PARAMETER EnumAsHex
+    Whether to format the enum values as a hex code and not a decimal.
+
+    .PARAMETER Rehydrate
+    Whether to mark the Python class as rehydrated or not.
+
+    .NOTES
+    It is recommended to use an instance of a type as '-InputObject'. Some properties are only added once the object
+    has been initialised so passing by type may miss some.
+
+    Do not use this to create a class for a 'PSCustomObject' instance.
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
+        [Object]
+        $InputObject,
+
+        [Switch]
+        $AddDoc,
+
+        [Switch]
+        $EnumAsHex,
+
+        [Switch]
+        $Rehydrate
+    )
+
+    begin {
+        $sb = New-Object -TypeName System.Text.StringBuilder
+
+        $null = $sb.Append(@'
+import pypsrp.dotnet as pynet
+
+
+'@)
+    }
+
+    process {
+        $type = $null
+        $typeNames = [System.Collections.Generic.List[String]]@()
+        $properties = [Ordered]@{
+            adapted = [Ordered]@{}
+            extended = [Ordered]@{}
+        }
+        $isEnum = $false
+
+        if ($InputObject -is [Type]) {
+            $type = $InputObject
+
+            $baseType = $InputObject
+            do {
+                $typeNames.Add($baseType.FullName)
+                $baseType = $baseType.BaseType
+            } while ($baseType.BaseType)
+            $typeNames.Add($baseType.FullName)
+
+            if ($InputObject.IsSubclassOf([System.Enum])) {
+                $isEnum = $true
+
+            } else {
+                foreach ($adapted in $InputObject.GetProperties()) {
+                    $properties.adapted.Add($adapted.Name, $adapted.PropertyType)
+                }
+
+                foreach ($extended in (Get-TypeData -TypeName $InputObject.FullName).Members.GetEnumerator()) {
+                    $name = $extended.Key
+                    $data = $extended.Value
+
+                    switch ($data.GetType().Name) {
+                        AliasPropertyData {
+                            $properties.extended.Add($name, $data.MemberType)
+                        }
+                        CodePropertyData {
+                            $properties.extended.Add($name, $data.GetCodeReference.ReflectedType)
+                        }
+                        NotePropertyData {
+                            $properties.extended.Add($name, $data.Value.GetType())
+                        }
+                        ScriptPropertyData {
+                            # Cannot determine the type as a ScriptBlock could output anything.
+                            $properties.extended.Add($name, $null)
+                        }
+                        default {}
+                    }
+                }
+            }
+
+        } else {
+            $type = $InputObject.GetType()
+            $typeNames = $InputObject.PSTypeNames
+
+            if ($type.IsSubclassOf([System.Enum])) {
+                $isEnum = $true
+
+            } else {
+                foreach ($adapted in $InputObject.PSAdapted.PSObject.Properties) {
+                    $properties.adapted.Add($adapted.Name, $adapted.TypeNameOfValue -as [Type])
+                }
+
+                foreach ($extended in $InputObject.PSExtended.PSObject.Properties) {
+                    $properties.extended.Add($extended.Name, $extended.TypeNameOfValue -as [Type])
+                }
+            }
+        }
+
+        $enumValues = [System.Collections.Generic.List[String]]@()
+        if ($isEnum) {
+            $rawType = [System.Enum]::GetUnderlyingType($type)
+            foreach ($name in ([System.Enum]::GetValues($type))) {
+                $rawName = $name.ToString()
+
+                # None is a reserved character in Python, need to lowercase this
+                if ($rawName -ceq 'None') {
+                    $rawName = 'none'
+                }
+                $rawValue = $name -as $rawType
+
+                if ($EnumAsHex) {
+                    $hexLength = ("{0:X}" -f $rawType::MaxValue).Length
+
+                    $rawValue = ("0x{0:X$($hexLength)}" -f $rawValue)
+                }
+
+                $enumValues.Add("$rawName = $rawValue")
+            }
+
+
+            if ($type.CustomAttributes | Where-Object { $_.AttributeType.FullName -eq 'System.FlagsAttribute' }) {
+                $enumType = 'PSFlagBase'
+
+            } else {
+                $enumType = 'PSEnumBase'
+            }
+
+            $rawType = ConvertTo-PythonPrimitiveType -InputObject $rawType
+            $null = $sb.AppendLine("`nclass PSEnum$($type.Name)(pynet.$enumType, pynet.$rawType):")
+
+        } else {
+            $null = $sb.AppendLine("`nclass PS$($type.Name)(pynet.PSObject):")
+        }
+
+        if ($AddDoc) {
+            $null = $sb.AppendLine(@"
+    """Python class for $($type.FullName)
+
+    This is an auto-generated Python class for the $($type.FullName) .NET class.
+    """
+"@)
+        }
+
+        $null = $sb.AppendLine("    PSObject = pynet.PSObjectMeta(")
+
+        # Define the object's types
+        $null = $sb.AppendLine("        type_names=[")
+        foreach ($name in $typeNames) {
+            $null = $sb.AppendLine("            '$name',")
+
+        }
+        $null = $sb.AppendLine("        ],")
+
+        foreach ($propType in $properties.GetEnumerator()) {
+            if (-not $propType.Value.Count) {
+                continue
+            }
+
+            $null = $sb.AppendLine("        $($propType.Key)_properties=[")
+            foreach ($prop in $propType.Value.GetEnumerator()) {
+                $psType = ConvertTo-PythonPrimitiveType -InputObject $prop.Value
+
+                $typeValue = $null
+                if ($psType) {
+                    $typeValue = ", ps_type=$psType"
+                }
+                $null = $sb.AppendLine("            pynet.PSPropertyInfo('$($prop.Key)'$typeValue),")
+            }
+
+            $null = $sb.AppendLine("        ],")
+        }
+
+        if ($Rehydrate) {
+            $null = $sb.AppendLine("        rehydrate=True,")
+        }
+
+        $null = $sb.AppendLine("    )`n")
+
+        if ($enumValues) {
+            foreach ($enumValue in $enumValues) {
+                $null = $sb.AppendLine("    $enumValue")
+            }
+            $null = $sb.AppendLine()
+        }
+    }
+
+    end {
+        $sb.ToString()
+    }
+}

--- a/docs/types.md
+++ b/docs/types.md
@@ -1,0 +1,513 @@
+# Python to .NET Type Information
+
+This is a guide on how to write .NET types as a Python class and the behaviour of these classes on deserialization.
+This is all based on the new V2 serialization work that has recently been implementation. To ensure the changes didn't
+break any existing scripts using the new serializer is an opt-in choice but it will be the defaults in a future version
+of `pypsrp`.
+
+
+## Behaviour of PowerShell Objects
+
+PowerShell objects are effectively .NET types with an extended type system. This allows an existing .NET type to be
+extended with extra properties that don't exist in the base .NET type. While there are many types of properties when an
+object is serialized it categorises them into 2 different types:
+
+* Adapted Properties `<Props>`: The base properties that exist on the .NET type
+* Extended Properties `<MS>`: Extra properties added by PowerShell
+
+Some key behaviours of PowerShell objects are:
+
+* An adapted and extended property can share the same name, when accessed in PowerShell the extended property is favoured
+* Property names can be any anything except `$null`, or one of the following reserved names
+    * `PSObject` - the metadata of the object, i.e. properties, type names of the object
+    * `PSBase` - the object but with the extended properties stripped out
+    * `PSAdapted` - all the adapted properties
+    * `PSExtended` - all the extended properties
+    * `PSTypeNames` - a list of type names that the object implements
+* Property names in PowerShell are also case insensitive
+* Properties can be accessed through an index and not dot notation, i.e. `$obj['PropertyName']`
+    * When dealing with indexable objects like a hashtable, the index will lookup the property first then the object
+
+### Accessing Properties in Python
+
+The goal of `pypsrp` is to try and replicate the same behaviour around .NET objects that are deserialized to a Python
+ object as best as it can. It is largely successful except for these key differences:
+
+* Properties are case sensitive in Python
+* When dealing with a dict and using the index lookup, it will lookup the dict elements first before it looks at the properties
+* A `System.Boolean/bool` in PowerShell can have extended properties, Python does not allow us to subclass the `bool` type so these properties are dropped
+* The `PSBase` property is not implemented, will just return `None` for now
+* PowerShell automatically adds the `PSComputerName` and `RunspaceId` extended property to each object returned from a remote runspace, `pypsrp` does not TODO: Should we do this?
+
+In PowerShell you commonly access properties in 2 main ways
+
+```powershell
+# Using the dot notation
+$obj.PropertyName
+
+# Using an index lookup
+$obj['PropertyName']
+```
+
+On a deserialized object, the property values are stored in `obj.PSObject` depending on the property type but they can
+be accessed like a normal attribute or through an index lookup like:
+
+```python
+# Using the dot notation
+obj.PropertyName
+
+# Using an index lookup
+obj['PropertyName']
+```
+
+There are a few limitations when it comes to the Python implementation:
+
+* You cannot do `obj."Property Name"`
+    * Python is a lot stricter on what valid attribute names are
+    * If you need to access a complex property name use the index lookup notation, e.g. `obj['Property Name']`
+* Using the index lookup to access a property requires a native string
+    * This is not a problem on Python 3 as native strings are already unicode, so you can do `obj['café']`
+    * On Python 2 a native string is technically a byte string so you will be fine when dealing with pure ASCII character
+    * When dealing with non-ASCII chars like `é`, Python may encode that value using a different encoding so the lookup will fail
+    * For Python 2 you need to use a UTF-8 encoded native string, i.e. `obj[u'café'.encode('utf-8')]`
+
+You can also access the same reserved property names like `PSObject`, `PSBase`, `PSTypeNames`, etc on a Python instance
+of a .NET object. The information it returns is similar to PowerShell but with some minor differences:
+
+* `PSBase`: Isn't implemented right now and will return `None`, use `PSAdapted` to get the adapted properties of the object.
+* `PSAdapted`: Just returns a dict where the keys are the adapted properties of the object
+* `PSExtended`: Also returns a dict where the keys are the extended properties of the object
+
+If you want to see all the properties of an object, similar to how `$obj | Select-Object -Property *` works you can use
+the `vars(obj)` function just like a normal Python object.
+
+```python
+vars(obj)
+
+# TODO: Give real example here
+```
+
+You could also loop through `obj.PSObject.adapted_properties` and `obj.PSObject.extended_properties` and view each
+property manually.
+
+
+## Class Mapping
+
+So far we've covered object properties in PowerShell and how they work in their Python equivalents the next step is to
+talk about the underlying class types and how they translate into Python and vice versa.
+
+In [MS-PSRP](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-psrp/602ee78e-9a19-45ad-90fa-bb132b7cecec)
+there are three different types of objects:
+
+* [Primitive types](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-psrp/c8c85974-ffd7-4455-84a8-e49016c20683)
+* [Complex types](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-psrp/406ad572-1ede-43e0-b063-e7291cda3e63)
+* Enum types - they are complex types but we consider them separate here
+
+### Primitive Types
+
+Primitive types are fundamental types that contain a value and optional properties. When it comes to working with
+primitive types for PSRP in Python, there exists a Python class for each primitive in `pypsrp.dotnet` that subclasses
+both `PSObject` as well as the Python type it closely resembles. Here is the mapping of the primitive types:
+
+| .NET | pypsrp.dotnet | Python Type (2/3) | Native |
+|-|-|-|-|
+| System.String | PSString | unicode/str | Y |
+| System.Char | PSChar | int¹ | N |
+| System.Boolean | PSBool² | bool | Y |
+| System.DateTime | PSDateTime | datetime.datetime | Y |
+| System.TimeSpan | PSDuration | unicode/str | N |
+| System.Byte | PSByte | int | N |
+| System.SByte | PSSByte | int | N |
+| System.UInt16 | PSUInt16 | int | N |
+| System.Int16 | PSInt16 | int | N |
+| System.UInt32 | PSUInt | int | N |
+| System.Int32 | PSInt | int | Y |
+| System.UInt64 | PSUInt64 | long/int | N |
+| System.Int64 | PSInt64 | long/int | N |
+| System.Single | PSSingle | float | Y |
+| System.Double | PSDouble | float | N |
+| System.Decimal | PSDecimal | decimal.Decimal | Y |
+| System.Byte[] | PSByteArray | str/bytes | Y |
+| System.Guid | PSGuid | uuid.UUID | Y |
+| System.Uri | PSUri | unicode/str | N |
+| $null | PSNull | None | Y |
+| System.Version | PSVersion | unicode/str | N |
+| System.Xml.XmlDocument | PSXml | unicode/str | N |
+| System.Management.Automation.ScriptBlock | PSScriptBlock | unicode/str | N |
+| System.Security.SecureString | PSSecureString³ | unicode/str | N |
+
+¹ - While the base Python type is an `int`, doing `PSChar('1')` will get the char based on the string value. Do `PSChar(1)` if you want the `PSChar` to represent `\u0001`.
+² - While there is a `pypsrp.dotnet` entry for these .NET types, they do not inherit `PSObject` so they cannot handle extended properties
+³ - A `PSSecureString` can be used to encrypt strings that traverse across the wire but the string in Python is not encrypted in memory, it acts like a normal string.
+
+If `Native` is `Y`, then `pypsrp` will automatically convert that native Python type to the .NET type for you.
+Otherwise the `pypsrp.dotnet` implementation must be used if you want to serialize a particular .NET type. For example
+if I was to pass in an `int` as an object, `pypsrp` will automatically serialize that to a `System.Int32` but say I
+wanted that to be a `System.UInt16` object I would need to pass in a `PSUInt16` instance instead.
+
+When a primitive type is deserialized, the instance will be the `pypsrp.dotnet` type. Due to how inheritance works you
+can do all of the following:
+
+```python
+import pypsrp.dotnet as dotnet
+
+...
+output = ps.invoke()[0]  # Our example outputs an Int32 value
+
+assert isinstance(output, dotnet.PSObject)  # Works for all except bool and $null
+assert isinstance(output, dotnet.PSInt)
+assert isinstance(output, int)
+```
+
+One last thing to note is that all string based types like `PSString`, `PSUri`, etc are all based on the text type of
+the Python version that is running. On Python 2 this is the `unicode` type created by string prefixed with `u""` and
+on Python 3 this is a native string, the `u""` prefix still works though. If writing Python 2 and 3 compatible code I
+recommend always using the `u""` prefix for string values or by importing `from __future__ import unicode_literals`.
+This avoids any ambiguity with native strings on Python 2 which are treated as a `Byte[]/PSByteArray` value.
+
+### Complex Types
+
+Complex types are the opposite of a primitive type. While primitive objects can be extended to include extended
+properties they are still considered a primitive object because it's a single value. A complex object typically is a
+class instance that contains both adapted and extended properties. They can also include container like object such
+as a dict, list, stack, queue, etc.
+
+While `pypsrp` supports (de)serialization of effectively any complex object, there are a few .NET complex types that
+are mapped to a specific Python class. These are:
+
+| .NET | pypsrp.dotnet | Python Type (2/3) | Native | Rehydrate |
+|-|-|-|-|-|
+| System.Collections.ArrayList¹ | PSList | list | Y | Y |
+| System.Collections.Hashtable¹ | PSDict | dict | Y | Y |
+| System.Collections.Stack¹ | PSStack | list | N | Y |
+| System.Collections.Queue¹ | PSQueue | Queue.Queue/queue.Queue | Y | Y |
+| System.Management.Automation.PSCustomObject | PSCustomObject | type² | Y | Y |
+| System.Management.Automation.PSCredential | PSCredential | - | N | Y |
+
+¹ - Other .NET types that are similar to this type are always deserialized to this .NET type, `pypsrp` acts the same, e.g. an` [Object[]]` will become a `PSList`
+² - Unless the type used is already a native implementation for another .NET type, it will automatically be serialized as a `PSCustomObject`
+
+Like a primitive object, when `Native` is `Y`, those Python types are automatically serialized to the .NET type it
+represents. If you wish to use a specific .NET type that does not natively do this, you need to use the
+`pypsrp.dotnet.PS<type>` class that represents the .NET type you desire or create your own.
+
+### Enum Types
+
+While technically a complex type I consider enums in PSRP to be a separate type of object that straddles both a
+primitive and complex type. Because of its uniqueness they are implemented slightly differently and have a few caveats
+in Python.
+
+There are 2 base enum types that can be used
+
+* `pypsrp.dotnet.PSEnumBase`: Inherits `PSObject`, used for enum types that should be set with a single value
+* `pypsrp.dotnet.PSFlagBase`: Inherits `PSEnumBase` but has special behaviour to allow multiple values to be set
+
+Like with .NET enums, the enums that inherit `PSEnumBase` or `PSFlagBase` must also inherit one of the
+[numeric types](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/integral-numeric-types)
+like:
+
+* `pypsrp.dotnet.PSByte`
+* `pypsrp.dotnet.PSSByte`
+* `pypsrp.dotnet.PSUInt16`
+* `pypsrp.dotnet.PSInt16`
+* `pypsrp.dotnet.PSUInt`
+* `pypsrp.dotnet.PSInt` (this is typically what you want to use)
+* `pypsrp.dotnet.PSUInt64`
+* `pypsrp.dotnet.PSInt64`
+
+When defining an enum a `PSObject` class attribute must be set as per any other `PSObject` type but any other class
+attributes are considered an enum label/value.
+
+There are a few things when it comes to implementing your own enum type
+
+* The enum names should match the .NET type, don't implement your own custom labels as the label is used to compute the `<ToString>` value in the CLIXML
+* If there is an enum label called `None`, use `none` instead
+* You must inherit from both `PSEnumBase/PSFlagBase` and one of the numeric types
+* If you don't mark the class with `rehydrate=True` then a deserialized instance of that enum will just be the primitive value of whatever numeric type the enum is based on
+* Because the instance inherits `int` in the end, you can utilise various numeric operators like bitwise and, bitwise or, addition, etc
+
+Here is an example of an basic enum [System.IO.FileMode](https://docs.microsoft.com/en-us/dotnet/api/system.io.filemode?view=netcore-3.1):
+
+```python
+import pypsrp.dotnet as pynet
+
+
+class IOFileMode(pynet.PSEnumBase, pynet.PSInt):
+
+    PSObject = pynet.PSObjectMeta(
+        type_names=['System.IO.FileMode', 'System.Enum', 'System.ValueType', 'System.Object'],
+        rehydrate=True,
+    )
+
+    Append = 6
+    Create = 2
+    CreateNew = 1
+    Open = 3
+    OpenOrCreate = 4
+    Truncate = 5
+```
+
+When you want to get an enum value just do `IOFileMode.Append` or with whatever label you need. Any instances of
+`PSEnumBase` will automatically convert the raw `int` value to an instance of that type, i.e. `IOFileMode.Append` will
+be `IOFileMode(6)`.
+
+Here is an example of a basic enum [System.IO.FileShare](https://docs.microsoft.com/en-us/dotnet/api/system.io.fileshare?view=netcore-3.1)
+that uses the `[FlagsAttributes]` to allow multiple values to be set.
+
+```python
+import pypsrp.dotnet as pynet
+
+
+class IOFileShare(pynet.PSFlagBase, pynet.PSInt):
+
+    PSObject = pynet.PSObjectMeta(
+        type_names=['System.IO.FileShare', 'System.Enum', 'System.ValueType', 'System.Object'],
+        rehydrate=True,
+    )
+
+    Delete = 4
+    Inheritable = 16
+    none = 0
+    Read = 1
+    ReadWrite = 3
+    Write = 2
+```
+
+Enums, like primitive objects can have further extended properties added to it if that is desired.
+
+
+## Implementing .NET Type in Python
+
+When implementing your own Python class to represent a .NET type there are few things you need to consider/understand:
+
+* The property names of the .NET class must match up with the ones defined on the Python class
+    * You can use the `@property` alias as a decorator if you wish to use things like to access attributes using the more pythonic `snake_case` format
+* When an object is serialized, property values are sourced from the property object inside `PSObject`
+    * Using a `@property` decorator to generate a calculated property value won't work
+    * The workaround is to set the property value to a function that is called during deserialization
+* Methods defined on the Python class are not transferred to PowerShell, only properties are
+* Whether you want the type to be rehydrated on deserialization or not
+    * This affects the `__init__()` signature as a rehydratable object must not have any required arguments 
+
+All custom .NET types in PowerShell that you implement *SHOULD* inherit from `pypsrp.dotnet.PSObject`. Any classes that
+do not inherit this type will be treated as a `PSCustomObject` which is explained a bit later. A class that inherits
+`PSObject` must have a class attribute `PSObject` that is set to an instance of `pypsrp.dotnet.PSObjectMeta`. The
+`PSObjectMeta` can be initialized with the following value:
+
+* `type_names`: (Required) A list of .NET types the object inherits, i.e. `['System.String', 'System.Object']`
+* `adapted_properties`: A list of `pypsrp.dotnet.PSPropertyInfo` instances that define the adapted properties of the object
+* `extended_properties`: A list of `pypsrp.dotnet.PSPropertyInfo` instances that define the extended properties of the object
+* `rehydrate`: Whether this type can be rehydrated (deserialized to this type) or not 
+* `tag`: The CLIXML tag element value to use, this should not be used for end users as all complex types are `Obj`
+
+The `adapted_properties` and `extended_properties` kwargs take a list of `pypsrp.dotnet.PSPropertyInfo` objects that
+define the properties of the object itself. Once a property has been defined on the object it is immediately
+gettable/settable like a normal attribute of an instance. The kwargs that `PSPropertyInfo` access are
+
+* `name`: The name of the property
+* `optional`: Whether this property is optional or not. If `True` then during serialization an unset property will have a `<Nil />` value, otherwise it is omitted altogether
+* `ps_type`: The primitive type (complex types aren't supported) to use when serializing an object. If set the property value will be casted to this type before it is serialized
+
+The `rehydrate` kwarg is used during serialization to determine the Python type that is used for the deserialized
+value. If `True` then any .NET objects that implement the same `type_names` will be a Python instance of the actual
+type. If `False` then the returned Python object will be a `pypsrp.dotnet.PSObject` will all the same properties set
+and the `obj.PSObject.type_names` will have `Deserialized.<type name>` on them. The only requirement for a class with
+`rehydrate=True` is that it's `__init__()` signature must have no mandatory arguments. When an instance of that class
+is created during de-serialization, it is just called with `Object()`. The main benefit `rehydrate=True` offers is it
+allows you do an `isinstance(obj, MyType)` check and control some extra instance init behaviour when the instance is
+created.
+
+Here is an example of how `pypsrp` implemented the [PSCredential](https://docs.microsoft.com/en-us/dotnet/api/system.management.automation.pscredential?view=powershellsdk-7.0.0)
+type.
+
+```python
+from pypsrp.dotnet import (
+    PSObject,
+    PSObjectMeta,
+    PSPropertyInfo,
+    PSString,
+    PSSecureString,
+)
+
+
+class PSCredential(PSObject):
+
+    PSObject = PSObjectMeta(
+        type_names=['System.Management.Automation.PSCredential', 'System.Object'],
+        adapted_properties=[
+            PSPropertyInfo('UserName', ps_type=PSString),
+            PSPropertyInfo('Password', ps_type=PSSecureString),
+        ],
+        rehydrate=True,  # Because __init__ does not have any required args, we can rehydrate this object.
+    )
+
+    def __init__(self, UserName=None, Password=None):
+        self.UserName = UserName
+        self.Password = Password
+```
+
+We can see that the `type_names` is set to the types that the object inherits starting from top down and the adapted
+properties and the types they should be coerced to when being serialized. The `__init__` method is not required but
+added as a convenience for people who want to create an object in one line.
+
+Creating your own types is usually just about getting the metadata of the type and defining it under `PSObject`. You
+can expand on it however you wish. To help with creating your own classes I've written a PowerShell function called
+[ConvertTo-PythonClass](ConvertTo-PythonClass.ps1) that you can use to generate a skeleton class in Python. This
+skeleton can adjusted based on your requirements to include extra methods/properties for use on the Python side.
+
+```powershell
+$obj = Get-Item -Path C:\Windows
+$obj | ConvertTo-PythonClass -AddDoc -Rehydrate
+
+# import pypsrp.dotnet as pynet
+#
+#
+# class PSDirectoryInfo(pynet.PSObject):
+#     """Python class for System.IO.DirectoryInfo
+#
+#     This is an auto-generated Python class for the System.IO.DirectoryInfo .NET class.
+#     """
+#     PSObject = pynet.PSObjectMeta(
+#         type_names=[
+#             'System.IO.DirectoryInfo',
+#             'System.IO.FileSystemInfo',
+#             'System.MarshalByRefObject',
+#             'System.Object',
+#         ],
+#         adapted_properties=[
+#             pynet.PSPropertyInfo('Parent'),
+#             pynet.PSPropertyInfo('Root'),
+#             pynet.PSPropertyInfo('FullName', ps_type=PSString),
+#             pynet.PSPropertyInfo('Extension', ps_type=PSString),
+#             pynet.PSPropertyInfo('Name', ps_type=PSString),
+#             pynet.PSPropertyInfo('Exists', ps_type=PSBool),
+#             pynet.PSPropertyInfo('CreationTime', ps_type=PSDateTime),
+#             pynet.PSPropertyInfo('CreationTimeUtc', ps_type=PSDateTime),
+#             pynet.PSPropertyInfo('LastAccessTime', ps_type=PSDateTime),
+#             pynet.PSPropertyInfo('LastAccessTimeUtc', ps_type=PSDateTime),
+#             pynet.PSPropertyInfo('LastWriteTime', ps_type=PSDateTime),
+#             pynet.PSPropertyInfo('LastWriteTimeUtc', ps_type=PSDateTime),
+#             pynet.PSPropertyInfo('Attributes'),
+#         ],
+#         extended_properties=[
+#             pynet.PSPropertyInfo('PSPath', ps_type=PSString),
+#             pynet.PSPropertyInfo('PSParentPath', ps_type=PSString),
+#             pynet.PSPropertyInfo('PSChildName', ps_type=PSString),
+#             pynet.PSPropertyInfo('PSDrive'),
+#             pynet.PSPropertyInfo('PSProvider'),
+#             pynet.PSPropertyInfo('PSIsContainer', ps_type=PSBool),
+#             pynet.PSPropertyInfo('Mode', ps_type=PSString),
+#             pynet.PSPropertyInfo('ModeWithoutHardLink', ps_type=PSString),
+#             pynet.PSPropertyInfo('BaseName'),
+#             pynet.PSPropertyInfo('Target', ps_type=PSString),
+#             pynet.PSPropertyInfo('LinkType', ps_type=PSString),
+#         ],
+#         rehydrate=True,
+#     )
+```
+
+One really common object that is used in PowerShell is the [PSCustomObject](https://docs.microsoft.com/en-us/dotnet/api/system.management.automation.pscustomobject?view=powershellsdk-7.0.0)
+object. This is typically created using `[PSCustomObject]@{ ... }` and `pypsrp` has 2 ways of implementing the same
+concept.
+
+```python
+from pypsrp.dotnet import PSCustomObject
+
+# Using PSObjectObject({'key': 'value'})
+ps_custom_object = PSCustomObject({
+    'PropertyName': 'name',
+    'AnotherProperty': 1,
+})
+
+# Using a plain Python class
+class MyPSCustomObject:
+
+    def __init__(self, PropertyName, AnotherProperty):
+        self.PropertyName = PropertyName
+        self.AnotherProperty = AnotherProperty
+
+ps_custom_object = MyPSCustomObject('name', 1)
+```
+
+The first example is a lot simpler and works in a similar way to how `[PSCustomObject]$hash` works but the latter
+allows you to control more aspect when generating the object such as mandatory arguments, calculated properties,
+custom methods on the Python side, etc. When the serializer detects an object that does not inherit
+`pypsrp.dotnet.PSObject` it does the following:
+
+* If it's a known native type like `str`, `int`, it will serialize it as the [primitive type it maps to](#primitive-types)
+* Otherwise is creates a `PSCustomObject` with it's properties set to all the instances properties and attributes
+
+When it comes to deserializing a `PSCustomObject`, there is no rehydration behaviour. It will always be deserialized as
+a `pypsrp.dotnet.PSCustomObject`.
+
+
+## Deserialization Behaviour
+
+Here is a brief overview of how `pypsrp` deserializes CLIXML to an object
+
+* Check if the CLIXML is a basic primitive type or not (XML tag != `Obj`).
+    * If it's a primitive type, create new instance for the matching type and return it
+* When it's a complex object, it will search the `TypeRegistry` to see if the type has been registered
+    * If the type is registered a new blank instance of the registered class for that type is created
+    * If the type is not registered, or the init above failed, a blank `PSObject` is created
+    * In the latter case the `PSTypeNames` for the next object are prefixed with `Deserialized.<TypeName>`
+* If the CLIXML contains a `<ToString>` value, that is registered to the object's metadata so `str(obj)` outputs that value
+* It will scan all adapted and extended properties in the CLIXML and add them to the value
+    * Even if a rehydrated object was used and did not have that property in the class metadata it will still be added to the new instance
+    * This also applies to enums and extended primitive objects
+* If the object wraps a dictionary (XML tag == `DCT`)
+    * The value becomes `pypsrp.dotnet.PSDict` and is populated with the dict elements
+* If the object wraps a stack (XML tag == `STK`)
+    * The value becomes `pypsrp.dotnet.PSStack` and is populated with the stack elements
+* If the object wraps a queue (XML tag == `QUE`)
+    * The value becomes `pypsrp.dotnet.PSQueue` and is populated with the queue elements
+* If the object wraps a list (XML tag == `LST` or `IE`)
+    * The value becomes `pypsrp.dotnet.PSList` and is populated with the list elements
+* If the object contains a remaining value
+    * If the type names match a *registered rehydratable* enum, the enum value is set to this primitive value
+    * Else the value now becomes an instance of the primitive value specified instead of a `PSObject`
+
+The end result is:
+
+* Primitive objects are returned as primitive objects with any extra extended properties that may be present
+* Enums are returned as that enum if the enum type was registered with `rehydrate=True` at the class definition, otherwise the returned object is the primitive value the enum represents
+* Dictionaries are returned as `pypsrp.dotnet.PSDict`
+* Stacks are returned as `pypsrp.dotnet.PSStack`
+* Queues are returned as `pypsrp.dotnet.PSQueue`
+* Lists are returned as `pypsrp.dotnet.PSList`
+* Other objects are returned as that object if the type was registered with `rehydrate=True` at the class definition, otherwise a `pypsrp.dotnet.PSObject` is created and has the extended properties set
+
+The `TypeRegistry` mentioned above is a special singleton created by `pypsrp` that contains all the types that inherit
+`PSObject` and set `rehydrate=True` in it's metadata. This registry is used to deserialize CLIXML to the proper Python
+type if available. The only differences between a rehydrated and plain `PSObject` object are:
+
+* A rehydrated object is an instance of that registered type, so any methods or properties are accessible
+* A non-rehydrated object is an instance of `pypsrp.dotnet.PSObject`, all the properties are still available
+* A rehydrated object keeps the type names under `obj.PSTypeNames` the way they were in the CLIXML
+* A non-rehydrated object will prefix all of its type names under `obj.PSTypeNames` with `Deserialized.`.
+
+## Add-Member
+
+In PowerShell you can add extra properties to an existing object using the [Add-Member](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/add-member?view=powershell-7)
+cmdlet. You can achieve a similar thing in `pypsrp` by adding a new `pypsrp.dotnet.PSPropertyInfo` to the instance's
+desired `PSObject` property list.
+
+TODO: Add examples
+
+
+## Update-TypeData
+
+Similar to `Add-Member`, the [Update-TypeData](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/update-typedata?view=powershell-7)
+allows you to add extra properties and methods to an existing type that is automatically inherited by any instance of
+that type. This allows you to do something like setting an alias of property to another name like:
+
+```powershell
+Update-TypeData -TypeName 'System.DateTime' -MemberType ScriptProperty -MemberName 'Quarter' -Value {
+  if ($this.Month -in @(1,2,3)) {"Q1"}
+  elseif ($this.Month -in @(4,5,6)) {"Q2"}
+  elseif ($this.Month -in @(7,8,9)) {"Q3"}
+  else {"Q4"}
+}
+```
+
+TODO: Implement this behaviour in Python.

--- a/pypsrp/dotnet.py
+++ b/pypsrp/dotnet.py
@@ -1,0 +1,840 @@
+# Copyright: (c) 2020, Jordan Borean (@jborean93) <jborean93@gmail.com>
+# MIT License (see LICENSE or https://opensource.org/licenses/MIT)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type  # noqa (fixes E402 for the imports below)
+
+import datetime
+import decimal
+import six
+import struct
+import uuid
+
+from pypsrp._utils import (
+    to_bytes,
+    to_string,
+    to_unicode,
+)
+
+try:
+    from typing import (
+        Dict,
+        List,
+        Optional,
+        Tuple,
+    )
+except ImportError:  # pragma: no cover
+    # Python2 does not have typing
+    Dict = None
+    List = None
+    Optional = None
+    Tuple = None
+
+try:
+    from queue import Queue
+except ImportError:  # pragma: no cover
+    from Queue import Queue
+
+if six.PY2:
+    large_int = long
+    unichr = unichr
+else:
+    large_int = int
+    unichr = chr
+
+
+class _Singleton(type):
+    __instances = {}
+
+    def __call__(cls, *args, **kwargs):
+        if cls not in cls.__instances:
+            cls.__instances[cls] = super(_Singleton, cls).__call__(*args, **kwargs)
+
+        return cls.__instances[cls]
+
+
+@six.add_metaclass(_Singleton)
+class TypeRegistry:
+    """Registry of all the Python classes that implement PSObject.
+
+    This singleton is used to store all the classes that implement PSObject and the .NET type it implements. This is
+    used for deserialization to provide a dynamic list of Python classes that can be dehydrated.
+    """
+
+    def __init__(self):  # type: () -> None
+        self.registry = {}
+
+    def register(self, type_name, cls):  # type: (str, type) -> None
+        """ Register a type that can be used for rehydration. """
+        if type_name not in self.registry:
+            self.registry[type_name] = cls
+
+    def rehydrate(self, type_names):  # type: (List[str]) -> PSObject
+        """ Rehydrate a blank instance based on the type names. """
+        # If the type is registered, return that actual type.
+        type_name = type_names[0] if type_names else None
+        if type_name and type_name in self.registry:
+            # Try and create the object, ignore errors and fallback to PSObject if we cannot init it.
+            try:
+                return self.registry[type_name]()
+            except TypeError:
+                pass
+
+        # The type is not registered, return a PSObject with the type names set to 'Deserialized.<TN>'.
+        obj = PSObject()
+        obj.PSObject = PSObjectMeta(["Deserialized.%s" % tn for tn in type_names])
+        return obj
+
+
+class _PSMetaType(type):
+    """PowerShell object meta type.
+
+    This is a meta type that is assigned to PSObject and any class that inherits PSObject will be initialised through
+    this type. It enforces the presence of the PSObject class attribute that describes how to (de)serialize the Python
+    class to a .NET type through CLIXML. It is also used to automatically register any rehydratable objects in the
+    TypeRegister so they are easily rehydrated by the serializer.
+    """
+    __registry = TypeRegistry()
+
+    def __init__(cls, name, bases, attributes):
+        super(_PSMetaType, cls).__init__(name, bases, attributes)
+        obj_type = '%s.%s' % (cls.__module__, cls.__name__)
+
+        # Except for some special base objects, all classes of this type must have a valid PSObject class attribute.
+        # We check the type name as a string because those classes are defined yet.
+        if cls.__module__ == _PSMetaType.__module__ and cls.__name__ in ['PSObject', 'PSEnumBase', 'PSFlagBase']:
+            return
+
+        ps_object = cls.PSObject
+        if not hasattr(ps_object, 'type_names') or len(ps_object.type_names) < 1:
+            raise ValueError('%s''s PSObject class attribute must have at least 1 type_name defined' % obj_type)
+
+        if ps_object.rehydrate:
+            cls.__registry.register(ps_object.type_names[0], cls)
+
+        if issubclass(cls, PSEnumBase):
+            # Convert the class attributes representing the enum values to an instance of that class.
+            for k, v in attributes.items():
+                if k.startswith('__') or k == 'PSObject':
+                    continue
+
+                enum_val = cls(v)
+                setattr(cls, k, enum_val)
+
+                # Make sure the class' PSObject has the enum map. Special edge case for none -> None as None is a
+                # reserved keyword in Python but the string should still show the capitalised version.
+                if k == 'none':
+                    k = 'None'
+                cls.PSObject.enum_map.append((v, k))
+
+
+class PSObjectMeta:
+
+    def __init__(self, type_names, adapted_properties=None, extended_properties=None, rehydrate=True, tag='Obj'):
+        # type: (List[str], Optional[List[PSPropertyInfo]], Optional[List[PSPropertyInfo]], bool, str) -> None
+        """The PowerShell object metadata.
+
+        This describes the metadata around how to (de)serialize the Python class to a .NET type through CLIXML. The
+        value should be assigned to the PSObject class attribute of any class that inherits from PSObject.
+
+        Using `rehydrate=True` can only be done on types that do not have any mandatory args on the `__init__()`
+        function. When the object is deserialized the deserialized object will be an actual instance of the registered
+        Python type rather than a generic PSObject.
+
+        Setting `tag` should only be set by the builtin types to pypsrp.
+
+        Args:
+            type_names: List of .NET type names that the type implements, this should contains at least 1 type.
+            adapted_properties: List of adapted properties, these are native to the .NET type.
+            extended_properties: List of extended properties, these are added to the .NET type by PowerShell.
+            rehydrate: Whether the type is able to be rehydrated or not.
+            tag: The CLIXML element tag, this is designed for internal use.
+
+        Attributes:
+            type_names (List[str]): See args.
+            adapted_properties (List[str]): See args.
+            extended_properties (List[str]): See args.
+            rehydrate (bool): See args.
+            tag (str): See args.
+            to_string (Optional[six.text_type]): Set to the `<ToString>` element if the object was deserialized.
+            enum_map (List[Tuple[int, str]]): A list of enum values and their label when the type is a PSEnumBase.
+        """
+        self.type_names = type_names
+        self.adapted_properties = adapted_properties or []
+        self.extended_properties = extended_properties or []
+        self.rehydrate = rehydrate
+        self.tag = tag
+        self.to_string = None
+        self.enum_map = []  # type: List[Tuple[int, str]]
+        self._xml = None  # type: Optional[six.text_type]
+
+    def new_instance_copy(self):  # type: () -> PSObjectMeta
+        """ Creates a copy of the existing meta to use for a new class instance. """
+        props = {
+            'adapted_properties': [],
+            'extended_properties': [],
+        }
+        for prop_name, prop_value in props.items():
+            for prop in getattr(self, prop_name):
+                prop_value.append(PSPropertyInfo(prop.name, prop.optional, prop.ps_type))
+
+        return PSObjectMeta(
+            type_names=list(self.type_names),
+            rehydrate=self.rehydrate,
+            tag=self.tag,
+            **props
+        )
+
+
+class PSPropertyInfo:
+
+    def __init__(self, name, optional=False, ps_type=None):
+        # type: (str, bool, Optional[type]) -> None
+        """Property metadata for an object's property.
+
+        The metadata for an object's property that describes how that property is serialized/deserialized.
+
+        Args:
+            name: The name of the property, this must match the Python/PS property name.
+            optional: Whether the property is optional or not.
+            ps_type: The actual primitive type to use when serializing the property.
+
+        Attributes:
+            name (str): See args.
+            optional (bool): See args.
+            ps_type (type): See args.
+            value (any): The value of the property.
+        """
+        self.name = to_string(name)
+        self.optional = optional
+        self.ps_type = ps_type
+        self.value = None
+
+
+@six.add_metaclass(_PSMetaType)
+class PSObject:
+    """The base PSObject type.
+
+    This is the base PSObject type that all PS object classes should inherit. It controls all the behaviour around
+    getting and setting attributes that are based on PowerShell properties in a way that is similar to PowerShell
+    itself.
+
+    This object should not be created by anybody as it is just used to set up the scaffolding around how Python
+    deals with PowerShell types.
+    """
+
+    PSObject = None  # Must be set by inheriting types
+
+    def __new__(cls, *args, **kwargs):
+        # Ensure every new object has an instance copy of the class PSObject.
+        if not issubclass(cls, PSEnumBase) and cls.PSObject and cls.PSObject.tag == 'Obj':
+            instance = super(PSObject, cls).__new__(cls)
+
+        else:
+            # Any primitive object is known to subclass multiple types, we preserve the args and kwargs so they are
+            # passing down to the Python type it subclasses.
+            instance = super(PSObject, cls).__new__(cls, *args, **kwargs)
+
+        if cls.PSObject:
+            instance.PSObject = instance.PSObject.new_instance_copy()
+
+        return instance
+
+    @property
+    def PSBase(self):
+        """ The raw .NET object without the extended type system properties. This is not yet implemented. """
+        return
+
+    @property
+    def PSAdapted(self):  # type: () -> Dict[str, any]
+        """ A dict of all the adapted properties. """
+        return dict((p.name, p.value) for p in self.PSObject.adapted_properties)
+
+    @property
+    def PSExtended(self):  # type: () -> Dict[str, any]
+        """ A dict of all the extended properties."""
+        return dict((p.name, p.value) for p in self.PSObject.extended_properties)
+
+    @property
+    def PSTypeNames(self):  # type: () -> List[str]
+        """ Shortcut to PSObject.type_names, one of PowerShells reserved properties. """
+        return self.PSObject.type_names
+
+    def __getattr__(self, item):
+        # The PS properties aren't actually an attribute on the object but self.__dict__ will still report they are.
+        # We just try and get the attribute from __dict__ and raise an AttributeError if that key was not found.
+        try:
+            return self.__dict__[item]
+        except KeyError:
+            pass
+
+        raise AttributeError("'%s' object has no attribute '%s'" % (self.__class__.__name__, item))
+
+    def __setattr__(self, key, value):
+        # Get the raw untainted __dict__ value which does not include our object's PS properties that self.__dict__
+        # will return. We use this to see whether we need to set the PSObject property or the Python object attribute.
+        d = super(PSObject, self).__getattribute__('__dict__')
+
+        # This must be done first before the key in properties check.
+        if key == 'PSObject':
+            return super(PSObject, self).__setattr__(key, value)
+
+        if key not in d:
+            ps_object = self.PSObject
+
+            # Extended props take priority, once we find a match we stopped checking.
+            for prop_type in ['extended', 'adapted']:
+                properties = getattr(ps_object, '%s_properties' % prop_type)
+                for prop in properties:
+                    if prop.name == key:
+                        prop.value = value
+                        return
+
+        # If the key already exists in the __dict__ or it's a new attribute that's not a registered property, just
+        # set the key/value to the object itself.
+        super(PSObject, self).__setattr__(key, value)
+
+    def __getattribute__(self, item):
+        val = super(PSObject, self).__getattribute__(item)
+
+        # In all cases we want to return the normal attribute Python would return except if __dict__ was called. In
+        # this case we make a copy and add the adapted and extended PS properties so that debuggers and calls like
+        # vars() and dir() will report them as attributes.
+        if item == '__dict__':
+            val = val.copy()  # Make sure we don't actually mutate the pure __dict__.
+            ps_object = self.PSObject
+
+            # Extended props take priority over adapted props, by checking that last we ensure the prop will have that
+            # value if there are duplicates.
+            for prop_type in ['adapted', 'extended']:
+                properties = getattr(ps_object, '%s_properties' % prop_type)
+                for prop in properties:
+                    val[prop.name] = prop.value
+
+        return val
+
+    def __getitem__(self, item):
+        """Allow getting properties using the index syntax.
+
+        By overriding __getitem__ you can access properties on an object using the index syntax, i.e.
+        obj['PropertyName']. This matches the PowerShell behaviour where properties can be retrieved either by dot
+        notation or by index notation.
+
+        It also makes it easier to get properties with a name that aren't valid attribute names in Python. By allowing
+        a string field someone can do `obj['1 Invalid Attribute$']`. An alternative option is through getattr() as
+        that accepts a string. This works because PSObject also override :func:`__getattr__` and :func:`__setattr__`
+        and it edits the `__dict__` directly.
+
+        This is complicated by the Dict/List/Stack/Queue types as we need this to preserve the actual lookup values.
+        In those cases the __getitem__ lookup will favour the base object items before falling back to looking at the
+        attributes.
+        """
+        return getattr(self, item)
+
+    def __setitem__(self, key, value):
+        setattr(self, key, value)
+
+    def __str__(self):
+        if self.PSObject.to_string is not None:
+            return to_string(self.PSObject.to_string)
+
+        else:
+            return super(PSObject, self).__str__()
+
+
+class PSEnumBase(PSObject):
+    """The base enum PSObject type.
+
+    This is the base enum PSObject type that all enum complex objects should inherit from. While we cannot use the
+    `enum` module as a PSObject has a different metaclass we can try and replicate some of the functionality here. Any
+    objects that inherit `PSEnumBase` should also inherit one of the integer PS types like `PSInt` and any other class
+    attributes (apart from PSObject) are treated as enum value. An example enum would look like:
+
+        class MyEnum(PSEnumBase, PSInt):
+            PSObject = PSObjectMeta(
+                type_names=['System.MyEnum', 'System.Enum', 'System.ValueType', 'System.Object'],
+                rehydrate=True,
+            )
+
+            Label = 1
+            Other = 2
+
+    A user of that enum would then access it like `MyEnum.Label` or `MyEnum.Other`. This class is designed for enums
+    that allow only 1 value, if you require a flag like enum, use `PSFlagBase` as the base type.
+    """
+
+    def __str__(self):
+        # The enum map is stored in the instance's class PSObject not the instance's PSObject.
+        enum_map = dict((k, v) for k, v in self.__class__.PSObject.enum_map)
+
+        return enum_map.get(self, 'Unknown')
+
+
+class PSFlagBase(PSEnumBase):
+    """The base flags enum PSObject type.
+
+    This is like `PSEnumBase` but supports having multiple values set like `[FlagsAttribute]` in .NET. Using any
+    bitwise operations will preserve the type so `MyFlags.Flag1 | MyFlags.Flag2` will still be an instance of
+    `MyFlags`.
+
+    Like `PSEnumBase`, an implementing type needs to inherit both `PSFlagBase` as well as one of the integer PS types
+    like `PSInt`. An example flag enum would look like:
+
+        class MyFlags(PSFlagBase, PSInt):
+            PSObject = PSObjectMeta(
+                type_names=['System.MyFlags', 'System.Enum', 'System.ValueType', 'System.Object'],
+                rehydrate=True,
+            )
+
+            Flag1 = 1
+            Flag2 = 2
+            Flag3 = 4
+    """
+
+    def __str__(self):
+        # The enum map is stored in the instance's class PSObject not the instance's PSObject.
+        enum_map = dict((k, v) for k, v in self.__class__.PSObject.enum_map)
+
+        val = int(self)
+
+        # Special edge case where the value is 0
+        if val == 0 and 0 in enum_map:
+            return enum_map[0]
+
+        elif 0 in enum_map:
+            del enum_map[0]
+
+        flag_list = []
+        for enum_val, enum_name in enum_map.items():
+            if val & enum_val == enum_val:
+                flag_list.append(enum_name)
+                val &= ~enum_val
+
+            if val == 0:
+                break
+
+        return ', '.join(flag_list)
+
+    def __and__(self, other):
+        return self.__class__(super(PSFlagBase, self).__and__(other))
+
+    def __or__(self, other):
+        return self.__class__(super(PSFlagBase, self).__or__(other))
+
+    def __xor__(self, other):
+        return self.__class__(super(PSFlagBase, self).__xor__(other))
+
+    def __lshift__(self, other):
+        return self.__class__(super(PSFlagBase, self).__lshift__(other))
+
+    def __rshift__(self, other):
+        return self.__class__(super(PSFlagBase, self).__rshift__(other))
+
+    def __invert__(self):
+        return self.__class__(super(PSFlagBase, self).__invert__())
+
+
+class PSCustomObject(PSObject):
+
+    PSObject = PSObjectMeta(type_names=['System.Management.Automation.PSCustomObject', 'System.Object'])
+
+    def __init__(self, properties=None):
+        if not properties:
+            return
+
+        for prop_name, prop_value in properties.items():
+            # Special use case with [PSCustomObject]@{PSTypeName = 'TypeName'} in PowerShell where the value is
+            # added to the top of the objects type names.
+            if prop_name == 'PSTypeName':
+                self.PSObject.type_names.insert(0, prop_value)
+
+            else:
+                self.PSObject.extended_properties.append(PSPropertyInfo(prop_name))
+                self[prop_name] = prop_value
+
+
+class PSString(PSObject, six.text_type):
+    """[MS-PSRP] 2.2.5.1.1 - String
+
+    https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-psrp/052b8c32-735b-49c0-8c24-bb32a5c871ce
+    """
+    PSObject = PSObjectMeta(['System.String', 'System.Object'], tag='S')
+
+    def __init__(self, *args, **kwargs):
+        super(PSString, self).__init__()
+
+    def __getslice__(self, start, stop):
+        return self.__getitem__(slice(start, stop))
+
+    def __getitem__(self, item):
+        if isinstance(item, six.string_types):
+            return super(PSString, self).__getitem__(item)
+
+        else:
+            # String indexing, need to preserve the PSObject.
+            val = PSString(six.text_type.__getitem__(self, item))
+            val.PSObject = self.PSObject
+            return val
+
+
+class PSChar(PSObject, int):
+    """[MS-PSRP] 2.2.5.1.2 - Character
+
+    A char in .NET represents a UTF-16 codepoint from `\u0000` to `\uFFFF`. The codepoint may not represent a valid
+    unicode character, say it's 1 half of a surrogate pair, but it's still a valid Char. A PSChar can be initialized
+    just like an `int()` as long as the value is from `0` to `65535` inclusive. A PSChar can also be initialized from
+    a single string character like `PSChar('a')`, any byte strings will be encoded as UTF-8 when getting the character.
+    If a decimal value is used as a string then the PSChar instance will be the value of that codepoint of the
+    character and not the decimal value itself.
+
+    https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-psrp/ff6f9767-a0a5-4cca-b091-4f15afc6e6d8
+    """
+    PSObject = PSObjectMeta(['System.Char', 'System.ValueType', 'System.Object'], tag='C')
+
+    def __init__(self, *args, **kwargs):
+        super(PSChar, self).__init__()
+
+    def __new__(cls, *args, **kwargs):
+        raw_args = list(args)
+
+        if isinstance(raw_args[0], (six.text_type, bytes)):
+            # Ensure we are dealing with a UTF-8 string before converting to UTF-16
+            b_value = to_bytes(to_unicode(raw_args[0]), encoding='utf-16-le')
+            if len(b_value) > 2:
+                raise ValueError('A PSChar must be 1 UTF-16 codepoint.')
+
+            raw_args[0] = struct.unpack("<H", b_value)[0]
+
+        char = super(PSChar, cls).__new__(cls, *raw_args, **kwargs)
+        if char < 0 or char > 65535:
+            raise ValueError("A PSChar must be between 0 and 65535.")
+
+        return char
+
+    def __str__(self):
+        # While backed by an int value, the str representation should be the char it represents.
+        return to_string(unichr(self))
+
+
+PSBool = bool
+"""[MS-PSRP] - 2.2.5.1.3 - Boolean
+
+https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-psrp/8b4b1067-4b58-46d5-b1c9-b881b6e7a0aa
+XML Element: <B>
+
+Cannot subclass due to a limitation on Python. This unfortunately means we can't represent an extended primitive
+object of this type in Python as well.
+"""
+
+
+class PSDateTime(PSObject, datetime.datetime):
+    """[MS-PSRP] 2.2.5.1.4 - Date/Time
+
+    https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-psrp/a3b75b8d-ad7e-4649-bb82-cfa70f54fb8c
+    """
+    PSObject = PSObjectMeta(['System.DateTime', 'System.ValueType', 'System.Object'], tag='DT')
+
+    def __init__(self, *args, **kwargs):
+        super(PSDateTime, self).__init__()
+        self.nanosecond = 0
+
+
+class PSDuration(PSObject, six.text_type):
+    """[MS-PSRP] 2.2.5.1.4 - Duration
+
+    https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-psrp/434cd15d-8fb3-462c-a004-bcd0d3a60201
+    """
+    PSObject = PSObjectMeta(['System.TimeSpan', 'System.ValueType', 'System.Object'], tag='TS')
+
+    def __init__(self, *args, **kwargs):
+        super(PSDuration, self).__init__()
+
+
+class PSByte(PSObject, int):
+    """[MS-PSRP] 2.2.5.1.6 - Unsigned Byte
+
+    https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-psrp/6e25153d-77b6-4e21-b5fa-6f986895171a
+    """
+    PSObject = PSObjectMeta(['System.Byte', 'System.ValueType', 'System.Object'], tag='By')
+
+    def __init__(self, *args, **kwargs):
+        super(PSByte, self).__init__()
+
+
+class PSSByte(PSObject, int):
+    """[MS-PSRP] 2.2.5.1.7 - Signed Byte
+
+    https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-psrp/8046c418-1531-4c43-9b9d-fb9bceace0db
+    """
+    PSObject = PSObjectMeta(['System.SByte', 'System.ValueType', 'System.Object'], tag='SB')
+
+    def __init__(self, *args, **kwargs):
+        super(PSSByte, self).__init__()
+
+
+class PSUInt16(PSObject, int):
+    """[MS-PSRP] 2.2.5.1.8 - Unsigned Short
+
+    https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-psrp/33751ca7-90d0-4b5e-a04f-2d8798cfb419
+    """
+    PSObject = PSObjectMeta(['System.UInt16', 'System.ValueType', 'System.Object'], tag='U16')
+
+    def __init__(self, *args, **kwargs):
+        super(PSUInt16, self).__init__()
+
+
+class PSInt16(PSObject, int):
+    """[MS-PSRP] 2.2.5.1.9 - Signed Short
+
+    https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-psrp/e0ed596d-0aea-40bb-a254-285b71188214
+    """
+    PSObject = PSObjectMeta(['System.Int16', 'System.ValueType', 'System.Object'], tag='I16')
+
+    def __init__(self, *args, **kwargs):
+        super(PSInt16, self).__init__()
+
+
+class PSUInt(PSObject, int):
+    """[MS-PSRP] 2.2.5.1.10 - Unsigned Int
+    https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-psrp/7b904471-3519-4a6a-900b-8053ad975c08
+    """
+    PSObject = PSObjectMeta(['System.UInt32', 'System.ValueType', 'System.Object'], tag='U32')
+
+    def __init__(self, *args, **kwargs):
+        super(PSUInt, self).__init__()
+
+
+class PSInt(PSObject, int):
+    """[MS-PSRP] 2.2.5.1.11 - Signed Int
+    https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-psrp/9eef96ba-1876-427b-9450-75a1b28f5668
+    """
+    PSObject = PSObjectMeta(['System.Int32', 'System.ValueType', 'System.Object'], tag='I32')
+
+    def __init__(self, *args, **kwargs):
+        super(PSInt, self).__init__()
+
+
+class PSUInt64(PSObject, large_int):
+    """[MS-PSRP] 2.2.5.1.12 - Unsigned Long
+    https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-psrp/d92cd5d2-59c6-4a61-b517-9fc48823cb4d
+    """
+    PSObject = PSObjectMeta(['System.UInt64', 'System.ValueType', 'System.Object'], tag='U64')
+
+    def __init__(self, *args, **kwargs):
+        super(PSUInt64, self).__init__()
+
+
+class PSInt64(PSObject, large_int):
+    """[MS-PSRP] 2.2.5.1.13 - Signed Long
+    https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-psrp/de124e86-3f8c-426a-ab75-47fdb4597c62
+    """
+    PSObject = PSObjectMeta(['System.Int64', 'System.ValueType', 'System.Object'], tag='I64')
+
+    def __init__(self, *args, **kwargs):
+        super(PSInt64, self).__init__()
+
+
+class PSSingle(PSObject, float):
+    """[MS-PSRP] 2.2.5.1.14 - Float
+    https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-psrp/d8a5a9ab-5f52-4175-96a3-c29afb7b82b8
+    """
+    PSObject = PSObjectMeta(['System.Single', 'System.ValueType', 'System.Object'], tag='Sg')
+
+    def __init__(self, *args, **kwargs):
+        super(PSSingle, self).__init__()
+
+
+class PSDouble(PSObject, float):
+    """[MS-PSRP] 2.2.5.1.15 - Double
+    https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-psrp/02fa08c5-139c-4e98-a13e-45784b4eabde
+    """
+    PSObject = PSObjectMeta(['System.Double', 'System.ValueType', 'System.Object'], tag='Db')
+
+    def __init__(self, *args, **kwargs):
+        super(PSDouble, self).__init__()
+
+
+class PSDecimal(PSObject, decimal.Decimal):
+    """[MS-PSRP] 2.2.5.1.16 - Decimal
+    https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-psrp/0f760f90-fa46-49bd-8868-001e2c29eb50
+    """
+    PSObject = PSObjectMeta(['System.Decimal', 'System.ValueType', 'System.Object'], tag='D')
+
+    def __init__(self, *args, **kwargs):
+        super(PSDecimal, self).__init__()
+
+
+class PSByteArray(PSObject, bytes):
+    """[MS-PSRP] 2.2.5.1.17 - Array of Bytes
+    https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-psrp/489ed886-34d2-4306-a2f5-73843c219b14
+    """
+    PSObject = PSObjectMeta(['System.Byte[]', 'System.Array', 'System.Object'], tag='BA')
+
+    def __init__(self, *args, **kwargs):
+        super(PSByteArray, self).__init__()
+
+
+class PSGuid(PSObject, uuid.UUID):
+    """[MS-PSRP] 2.2.5.1.18 - GUID
+    https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-psrp/c30c37fa-692d-49c7-bb86-b3179a97e106
+    """
+    PSObject = PSObjectMeta(['System.Guid', 'System.ValueType', 'System.Object'], tag='G')
+
+    def __setattr__(self, name, value):
+        # UUID raises TypeError on __setattr__ and there are cases where we need to override the psobject attribute.
+        if name == 'psobject':
+            self.__dict__['psobject'] = value
+            return
+
+        super(PSGuid, self).__setattr__(name, value)
+
+
+class PSUri(PSObject, six.text_type):
+    """[MS-PSRP] 2.2.5.1.19 - URI
+    https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-psrp/4ac73ac2-5cf7-4669-b4de-c8ba19a13186
+    """
+    PSObject = PSObjectMeta(['System.Uri', 'System.Object'], tag='URI')
+
+    def __init__(self, *args, **kwargs):
+        super(PSUri, self).__init__()
+
+
+PSNull = None
+"""[MS-PSRP] 2.2.5.1.20 - Null Value
+https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-psrp/402f2a78-5771-45ae-bf33-59f6e57767ca
+XML Element: <Nil>
+"""
+
+
+class PSVersion(PSObject, six.text_type):
+    """[MS-PSRP] 2.2.5.1.21 - Version
+    https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-psrp/390db910-e035-4f97-80fd-181a008ff6f8
+    """
+    PSObject = PSObjectMeta(['System.Version', 'System.Object'], tag='Version')
+
+    def __init__(self, *args, **kwargs):
+        super(PSVersion, self).__init__()
+
+
+class PSXml(PSObject, six.text_type):
+    """[MS-PSRP] 2.2.5.1.22 - XML Document
+    https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-psrp/df5908ab-bb4d-45e4-8adc-7258e5a9f537
+    """
+    PSObject = PSObjectMeta(['System.Xml.XmlDocument', 'System.Xml.XmlNode', 'System.Object'], tag='XD')
+
+    def __init__(self, *args, **kwargs):
+        super(PSXml, self).__init__()
+
+
+class PSScriptBlock(PSObject, six.text_type):
+    """[MS-PSRP] 2.2.5.1.23 - ScriptBlock
+    https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-psrp/306af1be-6be5-4074-acc9-e29bd32f3206
+    """
+    PSObject = PSObjectMeta(['System.Management.Automation.ScriptBlock', 'System.Object'], tag='SBK')
+
+    def __init__(self, *args, **kwargs):
+        super(PSScriptBlock, self).__init__()
+
+
+class PSSecureString(PSObject, six.text_type):
+    """[MS-PSRP] 2.2.5.1.24 - Secure String
+    https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-psrp/69b9dc01-a843-4f91-89f8-0205f021a7dd
+
+    Note: A SecureString is not actually encrypted in memory on the Python host but just a way to mark a string to
+    encrypt as a SecureString across the wire.
+    """
+    PSObject = PSObjectMeta(['System.Security.SecureString', 'System.Object'], tag='SS')
+
+    def __init__(self, *args, **kwargs):
+        super(PSSecureString, self).__init__()
+
+
+class PSStack(PSObject, list):
+    """[MS-PSRP] 2.2.5.2.6.1 - Stack
+    https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-psrp/e9cf648e-38fe-42ba-9ca3-d89a9e0a856a
+    """
+    PSObject = PSObjectMeta(['System.Collections.Stack', 'System.Object'], tag='STK')
+
+    def __getitem__(self, item):
+        try:
+            return list.__getitem__(self, item)
+        except TypeError:
+            return super(PSStack, self).__getitem__(item)
+
+    def __setitem__(self, key, value):
+        if isinstance(key, six.string_types):
+            return super(PSStack, self).__setitem__(key, value)
+        else:
+            return list.__setitem__(self, key, value)
+
+
+class PSQueue(PSObject, Queue):
+    """[MS-PSRP] 2.2.5.2.6.2 - Queue
+    https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-psrp/ade9f023-ac30-4b7e-be17-900c02a6f837
+    """
+    PSObject = PSObjectMeta(['System.Collections.Queue', 'System.Object'], tag='QUE')
+
+    def __getitem__(self, item):
+        try:
+            return Queue.__getitem__(self, item)
+        except TypeError:
+            return super(PSQueue, self).__getitem__(item)
+
+    def __setitem__(self, key, value):
+        if isinstance(key, six.string_types):
+            return super(PSQueue, self).__setitem__(key, value)
+        else:
+            return Queue.__setitem__(self, key, value)
+
+
+class PSList(PSObject, list):
+    """[MS-PSRP] 2.2.5.2.6.3 - List
+    https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-psrp/f4bdb166-cefc-4d49-848c-7d08680ae0a7
+    """
+    # Would prefer an Generic.List<T> but regardless of the type a list is always deserialized by PowerShell as an
+    # ArrayList so just do that here.
+    PSObject = PSObjectMeta(['System.Collections.ArrayList', 'System.Object'], tag='LST')
+
+    def __getitem__(self, item):
+        try:
+            return list.__getitem__(self, item)
+        except TypeError:
+            return super(PSList, self).__getitem__(item)
+
+    def __setitem__(self, key, value):
+        if isinstance(key, six.string_types):
+            return super(PSList, self).__setitem__(key, value)
+        else:
+            return list.__setitem__(self, key, value)
+
+
+class PSDict(PSObject, dict):
+    """[MS-PSRP] 2.2.5.2.6.4 - Dictionaries
+    https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-psrp/c4e000a2-21d8-46c0-a71b-0051365d8273
+    """
+    PSObject = PSObjectMeta(['System.Collections.Hashtable', 'System.Object'], tag='DCT')
+
+    def __getitem__(self, item):
+        try:
+            return dict.__getitem__(self, item)
+        except KeyError:
+            return super(PSDict, self).__getitem__(item)
+
+    def __setitem__(self, key, value):
+        dict.__setitem__(self, key, value)
+
+
+class PSCredential(PSObject):
+
+    PSObject = PSObjectMeta(
+        type_names=['System.Management.Automation.PSCredential', 'System.Object'],
+        adapted_properties=[
+            PSPropertyInfo('UserName', ps_type=PSString),
+            PSPropertyInfo('Password', ps_type=PSSecureString),
+        ],
+        rehydrate=True,
+    )
+
+    def __init__(self, UserName=None, Password=None):
+        self.UserName = UserName
+        self.Password = Password

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -1,2 +1,2 @@
 # Other constraints
-pytest >= 3.6 ; python_version > "2.7"  # Make sure other Python versions use a newer version of pytest
+pytest > 5.0 ; python_version > "3"  # Make sure other Python versions use a newer version of pytest

--- a/tests/test_dotnet.py
+++ b/tests/test_dotnet.py
@@ -1,0 +1,508 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2020, Jordan Borean (@jborean93) <jborean93@gmail.com>
+# MIT License (see LICENSE or https://opensource.org/licenses/MIT)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type  # noqa (fixes E402 for the imports below)
+
+import pytest
+import six
+import xml.etree.ElementTree as ET
+
+import pypsrp.dotnet as dotnet
+
+from pypsrp.serializer import SerializerV2
+
+from pypsrp._utils import (
+    to_string,
+)
+
+
+# Contains control characters, non-ascii chars, and chars that are surrogate pairs in UTF-16
+COMPLEX_STRING = u'treble clef\n _x0000_ _X0000_ %s café' % b"\xF0\x9D\x84\x9E".decode('utf-8')
+COMPLEX_ENCODED_STRING = u'treble clef_x000A_ _x005F_x0000_ _x005F_X0000_ _xD834__xDD1E_ café'
+
+
+@pytest.mark.parametrize('rehydrate', [True, False])
+def test_ps_enum(rehydrate):
+    type_name = 'MyEnumRehydrated' if rehydrate else 'MyEnum'
+
+    class EnumTest(dotnet.PSEnumBase, dotnet.PSInt):
+        PSObject = dotnet.PSObjectMeta(type_names=['System.%s' % type_name, 'System.Object'], rehydrate=rehydrate)
+
+        none = 0
+        Value1 = 1
+        Value2 = 2
+        Value3 = 3
+
+    assert str(EnumTest.none) == 'None'
+    assert str(EnumTest.Value1) == 'Value1'
+    assert str(EnumTest.Value2) == 'Value2'
+    assert str(EnumTest.Value3) == 'Value3'
+
+    val = EnumTest.Value1
+    assert isinstance(val, dotnet.PSObject)
+    assert isinstance(val, dotnet.PSEnumBase)
+    assert isinstance(val, dotnet.PSInt)
+    assert isinstance(val, int)
+
+    element = SerializerV2().serialize(val)
+
+    actual = to_string(ET.tostring(element, encoding='utf-8'))
+    assert actual == '<Obj RefId="0"><I32>1</I32>' \
+                     '<TN RefId="0"><T>System.%s</T><T>System.Object</T></TN>' \
+                     '<ToString>Value1</ToString></Obj>' % type_name
+
+    actual = SerializerV2().deserialize(element)
+    assert actual == val
+    assert str(actual) == 'Value1'
+    assert isinstance(actual, dotnet.PSObject)
+    assert isinstance(actual, dotnet.PSInt)
+    assert isinstance(actual, int)
+
+    # Without hydration we just get the primitive value back
+    if rehydrate:
+        assert actual.PSTypeNames == ['System.%s' % type_name, 'System.Object']
+        assert isinstance(actual, dotnet.PSEnumBase)
+        assert isinstance(actual, EnumTest)
+
+    else:
+        assert actual.PSTypeNames == ['Deserialized.System.%s' % type_name, 'Deserialized.System.Object']
+        assert not isinstance(actual, dotnet.PSEnumBase)
+        assert not isinstance(actual, EnumTest)
+
+
+@pytest.mark.parametrize('rehydrate', [True, False])
+def test_ps_enum_unsigned_type(rehydrate):
+    type_name = 'EnumUIntRehydrated' if rehydrate else 'EnumUInt'
+
+    class EnumTest(dotnet.PSEnumBase, dotnet.PSUInt):
+        PSObject = dotnet.PSObjectMeta(type_names=['System.%s' % type_name, 'System.Object'], rehydrate=rehydrate)
+
+        none = 0
+        Value1 = 1
+        Value2 = 2
+        Value3 = 3
+
+    assert str(EnumTest.none) == 'None'
+    assert str(EnumTest.Value1) == 'Value1'
+    assert str(EnumTest.Value2) == 'Value2'
+    assert str(EnumTest.Value3) == 'Value3'
+
+    val = EnumTest.Value1
+    assert isinstance(val, dotnet.PSObject)
+    assert isinstance(val, dotnet.PSEnumBase)
+    assert isinstance(val, dotnet.PSUInt)
+    assert isinstance(val, int)
+
+    element = SerializerV2().serialize(val)
+
+    actual = to_string(ET.tostring(element, encoding='utf-8'))
+    assert actual == '<Obj RefId="0"><U32>1</U32>' \
+                     '<TN RefId="0"><T>System.%s</T><T>System.Object</T></TN>' \
+                     '<ToString>Value1</ToString></Obj>' % type_name
+
+    actual = SerializerV2().deserialize(element)
+    assert actual == val
+    assert str(actual) == 'Value1'
+    assert isinstance(actual, dotnet.PSObject)
+    assert isinstance(actual, dotnet.PSUInt)
+    assert isinstance(actual, int)
+
+    # Without hydration we just get the primitive value back
+    if rehydrate:
+        assert actual.PSTypeNames == ['System.%s' % type_name, 'System.Object']
+        assert isinstance(actual, dotnet.PSEnumBase)
+        assert isinstance(actual, EnumTest)
+
+    else:
+        assert actual.PSTypeNames == ['Deserialized.System.%s' % type_name, 'Deserialized.System.Object']
+        assert not isinstance(actual, dotnet.PSEnumBase)
+        assert not isinstance(actual, EnumTest)
+
+
+@pytest.mark.parametrize('rehydrate', [True, False])
+def test_ps_enum_extended_properties(rehydrate):
+    type_name = 'EnumExtendedRehydrated' if rehydrate else 'EnumExtended'
+
+    class EnumTest(dotnet.PSEnumBase, dotnet.PSInt64):
+        PSObject = dotnet.PSObjectMeta(type_names=['System.%s' % type_name, 'System.Object'], rehydrate=rehydrate)
+
+        none = 0
+        Value1 = 1
+        Value2 = 2
+        Value3 = 3
+
+    assert str(EnumTest.none) == 'None'
+    assert str(EnumTest.Value1) == 'Value1'
+    assert str(EnumTest.Value2) == 'Value2'
+    assert str(EnumTest.Value3) == 'Value3'
+
+    val = EnumTest.none
+    val.PSObject.extended_properties.append(dotnet.PSPropertyInfo('Test café'))
+    val['Test café'] = u'café'
+    assert isinstance(val, dotnet.PSObject)
+    assert isinstance(val, dotnet.PSEnumBase)
+    assert isinstance(val, dotnet.PSInt64)
+    assert isinstance(val, dotnet.large_int)
+
+    element = SerializerV2().serialize(val)
+
+    actual = to_string(ET.tostring(element, encoding='utf-8'))
+    assert actual == '<Obj RefId="0"><I64>0</I64>' \
+                     '<TN RefId="0"><T>System.%s</T><T>System.Object</T></TN>' \
+                     '<MS><S N="Test café">café</S></MS>' \
+                     '<ToString>None</ToString></Obj>' % type_name
+
+    actual = SerializerV2().deserialize(element)
+    assert actual == val
+    assert val['Test café'] == u'café'
+    assert str(actual) == 'None'
+    assert isinstance(actual, dotnet.PSObject)
+    assert isinstance(actual, dotnet.PSInt64)
+    assert isinstance(actual, dotnet.large_int)
+
+    # Without hydration we just get the primitive value back
+    if rehydrate:
+        assert actual.PSTypeNames == ['System.%s' % type_name, 'System.Object']
+        assert isinstance(actual, dotnet.PSEnumBase)
+        assert isinstance(actual, EnumTest)
+
+    else:
+        assert actual.PSTypeNames == ['Deserialized.System.%s' % type_name, 'Deserialized.System.Object']
+        assert not isinstance(actual, dotnet.PSEnumBase)
+        assert not isinstance(actual, EnumTest)
+
+
+@pytest.mark.parametrize('rehydrate', [True, False])
+def test_ps_flags(rehydrate):
+    type_name = 'FlagHydrated' if rehydrate else 'Flag'
+
+    class FlagTest(dotnet.PSFlagBase, dotnet.PSInt):
+        PSObject = dotnet.PSObjectMeta(type_names=['System.%s' % type_name, 'System.Object'], rehydrate=rehydrate)
+
+        none = 0
+        Flag1 = 1
+        Flag2 = 2
+        Flag3 = 4
+
+    assert str(FlagTest.none) == 'None'
+    assert str(FlagTest.Flag1) == 'Flag1'
+    assert str(FlagTest.Flag2) == 'Flag2'
+    assert str(FlagTest.Flag3) == 'Flag3'
+    assert str(FlagTest.Flag1 | FlagTest.Flag3) == 'Flag1, Flag3'
+
+    val = FlagTest.Flag1 | FlagTest.Flag3
+
+    assert isinstance(val, dotnet.PSObject)
+    assert isinstance(val, dotnet.PSEnumBase)
+    assert isinstance(val, dotnet.PSFlagBase)
+    assert isinstance(val, dotnet.PSInt)
+    assert isinstance(val, int)
+
+    element = SerializerV2().serialize(val)
+
+    actual = to_string(ET.tostring(element, encoding='utf-8'))
+    assert actual == '<Obj RefId="0"><I32>5</I32>' \
+                     '<TN RefId="0"><T>System.%s</T><T>System.Object</T></TN>' \
+                     '<ToString>Flag1, Flag3</ToString></Obj>' % type_name
+
+    actual = SerializerV2().deserialize(element)
+    assert actual == val
+    assert str(actual) == 'Flag1, Flag3'
+    assert isinstance(actual, dotnet.PSObject)
+    assert isinstance(actual, dotnet.PSInt)
+    assert isinstance(actual, int)
+
+    # Without hydration we just get the primitive value back
+    if rehydrate:
+        assert actual.PSTypeNames == ['System.%s' % type_name, 'System.Object']
+        assert isinstance(actual, dotnet.PSEnumBase)
+        assert isinstance(actual, dotnet.PSFlagBase)
+        assert isinstance(actual, FlagTest)
+
+    else:
+        assert actual.PSTypeNames == ['Deserialized.System.%s' % type_name, 'Deserialized.System.Object']
+        assert not isinstance(actual, dotnet.PSEnumBase)
+        assert not isinstance(actual, dotnet.PSFlagBase)
+        assert not isinstance(actual, FlagTest)
+
+
+def test_ps_custom_object_empty():
+    obj = dotnet.PSCustomObject()
+    assert obj.PSAdapted == {}
+    assert obj.PSExtended == {}
+    assert obj.PSTypeNames == ['System.Management.Automation.PSCustomObject', 'System.Object']
+
+    obj.PSObject.to_string = 'to string value'
+    element = SerializerV2().serialize(obj)
+
+    actual = to_string(ET.tostring(element, encoding='utf-8'))
+    assert actual == '<Obj RefId="0"><TN RefId="0"><T>System.Management.Automation.PSCustomObject</T><T>System.Object</T></TN>' \
+                     '<ToString>to string value</ToString>' \
+                     '</Obj>'
+
+    actual = SerializerV2().deserialize(element)
+    assert isinstance(actual, dotnet.PSCustomObject)
+    assert actual.PSAdapted == {}
+    assert actual.PSExtended == {}
+    assert actual.PSTypeNames == ['System.Management.Automation.PSCustomObject', 'System.Object']
+    assert str(actual) == 'to string value'
+
+
+def test_ps_custom_object_type_name():
+    obj = dotnet.PSCustomObject({'PSTypeName': 'MyType', 'My Property': 'Value'})
+    assert obj.PSAdapted == {}
+    assert obj.PSExtended == {'My Property': 'Value'}
+    assert obj.PSTypeNames == ['MyType', 'System.Management.Automation.PSCustomObject', 'System.Object']
+
+    obj.PSObject.to_string = 'to string value'
+    element = SerializerV2().serialize(obj)
+
+    actual = to_string(ET.tostring(element, encoding='utf-8'))
+    assert actual == '<Obj RefId="0"><TN RefId="0"><T>MyType</T><T>System.Management.Automation.PSCustomObject</T><T>System.Object</T></TN>' \
+                     '<MS><S N="My Property">Value</S></MS><ToString>to string value</ToString></Obj>'
+
+    actual = SerializerV2().deserialize(element)
+    assert isinstance(actual, dotnet.PSObject)
+    assert actual.PSAdapted == {}
+    assert actual.PSExtended == {'My Property': 'Value'}
+    assert actual.PSTypeNames == ['Deserialized.MyType', 'Deserialized.System.Management.Automation.PSCustomObject', 'Deserialized.System.Object']
+    assert str(actual) == 'to string value'
+
+
+def test_ps_flags_operators():
+    class FlagTest(dotnet.PSFlagBase, dotnet.PSInt):
+        PSObject = dotnet.PSObjectMeta(type_names=['System.FlagTest', 'System.Object'])
+
+        none = 0
+        Flag1 = 1
+        Flag2 = 2
+        Flag3 = 4
+        Flag4 = 8
+
+    val = FlagTest.none
+    assert str(val) == 'None'
+
+    val |= FlagTest.Flag1 | FlagTest.Flag2
+    assert isinstance(val, FlagTest)
+    assert str(val) == 'Flag1, Flag2'
+    assert val == 3
+
+    val &= FlagTest.Flag1
+    assert isinstance(val, FlagTest)
+    assert str(val) == 'Flag1'
+    assert val == 1
+
+    val = (FlagTest.Flag1 | FlagTest.Flag2) ^ FlagTest.Flag1
+    assert isinstance(val, FlagTest)
+    assert str(val) == 'Flag2'
+    assert val == 2
+
+    val = val << 2
+    assert isinstance(val, FlagTest)
+    assert str(val) == 'Flag4'
+    assert val == 8
+
+    val = val >> 1
+    assert isinstance(val, FlagTest)
+    assert str(val) == 'Flag3'
+    assert val == 4
+
+    val &= ~val
+    assert isinstance(val, FlagTest)
+    assert str(val) == 'None'
+    assert val == 0
+
+
+def test_ps_string():
+    ps_string = dotnet.PSString(COMPLEX_STRING)
+    element = SerializerV2().serialize(ps_string)
+
+    actual = to_string(ET.tostring(element, encoding='utf-8'))
+    assert actual == '<S>%s</S>' % COMPLEX_ENCODED_STRING
+
+    actual = SerializerV2().deserialize(element)
+    assert isinstance(actual, dotnet.PSString)
+    assert isinstance(actual, six.text_type)
+    assert actual == ps_string
+    assert actual.PSObject.type_names == ['System.String', 'System.Object']
+
+    # Check that we can still slice a string
+    sliced_actual = actual[:6]
+    assert isinstance(sliced_actual, dotnet.PSString)
+    assert isinstance(sliced_actual, six.text_type)
+    assert sliced_actual == COMPLEX_STRING[:6]
+
+
+def test_ps_string_with_properties():
+    n_special_str = to_string(COMPLEX_STRING)
+
+    ps_string = dotnet.PSString(COMPLEX_STRING)
+    ps_string.PSObject.extended_properties.append(dotnet.PSPropertyInfo('TestProperty'))
+    ps_string.PSObject.extended_properties.append(dotnet.PSPropertyInfo(n_special_str))
+    ps_string.TestProperty = u'property value'
+    ps_string[n_special_str] = u'other value'
+    element = SerializerV2().serialize(ps_string)
+
+    actual = to_string(ET.tostring(element, encoding='utf-8'))
+    assert actual == '<Obj RefId="0"><S>{0}</S><MS>' \
+                     '<S N="TestProperty">property value</S>' \
+                     '<S N="{0}">other value</S></MS></Obj>'.format(COMPLEX_ENCODED_STRING)
+
+    actual = SerializerV2().deserialize(element)
+    assert isinstance(actual, dotnet.PSString)
+    assert isinstance(actual, six.text_type)
+    assert actual == ps_string
+    assert actual['TestProperty'] == 'property value'
+    assert actual.TestProperty == 'property value'
+    assert actual[n_special_str] == 'other value'
+    assert actual.PSObject.type_names == ['System.String', 'System.Object']
+
+    # Check that we can still slice a string and properties are still preserved
+    sliced_actual = actual[:6]
+    assert isinstance(sliced_actual, dotnet.PSString)
+    assert isinstance(sliced_actual, six.text_type)
+    assert sliced_actual == COMPLEX_STRING[:6]
+    assert sliced_actual['TestProperty'] == 'property value'
+    assert sliced_actual[n_special_str] == 'other value'
+
+    # Check that a new PSString instance does not inherit the same PSObject values
+    new_str = dotnet.PSString('other')
+    assert new_str.PSObject.adapted_properties == []
+    assert new_str.PSObject.extended_properties == []
+
+
+@pytest.mark.parametrize('input_val', [
+    'decimal',
+    'text',
+])
+def test_ps_char(input_val):
+    sparkles = b"\x28\x27".decode('utf-16-le')
+    if input_val == 'decimal':
+        input_val = ord(sparkles)
+
+    else:
+        input_val = sparkles
+
+    ps_char = dotnet.PSChar(input_val)
+    assert isinstance(ps_char, dotnet.PSChar)
+    assert isinstance(ps_char, int)
+    assert str(ps_char) == to_string(sparkles)
+
+    element = SerializerV2().serialize(ps_char)
+
+    actual = to_string(ET.tostring(element, encoding='utf-8'))
+    assert actual == '<C>%s</C>' % int(ps_char)
+
+    actual = SerializerV2().deserialize(element)
+    assert isinstance(actual, dotnet.PSChar)
+    assert isinstance(actual, int)
+    assert actual == ps_char
+    assert int(actual) == ord(sparkles)
+    assert str(actual) == sparkles
+    assert actual.PSTypeNames == ['System.Char', 'System.ValueType', 'System.Object']
+
+
+@pytest.mark.parametrize('input_val, expected', [
+    (0, 0),
+    (u'\u0000', 0),
+    (1, 1),
+    ('1', 49),
+    (b"\xc3\xa9", 233),
+    (u"é", 233),
+    (65535, 65535),
+    (u"\uffff", 65535),
+])
+def test_ps_char_edge_cases(input_val, expected):
+    str_expected = to_string(dotnet.unichr(expected))
+
+    actual = dotnet.PSChar(input_val)
+    assert isinstance(actual, dotnet.PSChar)
+    assert actual == expected
+    assert str(actual) == str_expected
+
+    element = SerializerV2().serialize(actual)
+
+    actual = to_string(ET.tostring(element, encoding='utf-8'))
+    assert actual == '<C>%s</C>' % expected
+
+    actual = SerializerV2().deserialize(element)
+    assert isinstance(actual, dotnet.PSChar)
+    assert actual == expected
+    assert str(actual) == str_expected
+    assert actual.PSTypeNames == ['System.Char', 'System.ValueType', 'System.Object']
+
+
+@pytest.mark.parametrize('input_val', [
+    b"\xF0\x9D\x84\x9E".decode('utf-8'),
+    "2c",
+])
+def test_ps_char_invalid_string(input_val):
+    with pytest.raises(ValueError, match="A PSChar must be 1 UTF-16 codepoint"):
+        dotnet.PSChar(input_val)
+
+
+@pytest.mark.parametrize('input_val', [-1, 65536])
+def test_ps_char_invalid_int(input_val):
+    with pytest.raises(ValueError, match='A PSChar must be between 0 and 65535.'):
+        dotnet.PSChar(input_val)
+
+
+def test_ps_char_with_properties():
+    ps_char = dotnet.PSChar('c')
+    ps_char.PSObject.extended_properties.append(dotnet.PSPropertyInfo('Test Property'))
+    ps_char['Test Property'] = 1
+
+    element = SerializerV2().serialize(ps_char)
+
+    actual = to_string(ET.tostring(element, encoding='utf-8'))
+    assert actual == '<Obj RefId="0"><C>99</C><MS><I32 N="Test Property">1</I32></MS></Obj>'
+
+    actual = SerializerV2().deserialize(element)
+    assert isinstance(actual, dotnet.PSChar)
+    assert isinstance(actual, int)
+    assert actual == 99
+    assert str(actual) == 'c'
+    assert actual['Test Property'] == 1
+    assert isinstance(actual['Test Property'], dotnet.PSInt)
+    assert actual.PSTypeNames == ['System.Char', 'System.ValueType', 'System.Object']
+
+
+@pytest.mark.parametrize('input_val, expected', [
+    (True, True),
+    ('value', True),
+    (1, True),
+    (False, False),
+    ('', False),
+    (0, False),
+])
+def test_ps_bool(input_val, expected):
+    actual = dotnet.PSBool(input_val)
+    assert isinstance(actual, dotnet.PSBool)
+    assert isinstance(actual, bool)
+    assert actual == expected
+
+    element = SerializerV2().serialize(actual)
+
+    actual = to_string(ET.tostring(element, encoding='utf-8'))
+    print(actual)
+    assert actual == '<B>%s</B>' % str(expected).lower()
+
+    actual = SerializerV2().deserialize(element)
+    assert isinstance(actual, dotnet.PSBool)
+    assert isinstance(actual, bool)
+    assert not isinstance(actual, dotnet.PSObject)  # We cannot subclass bool so this won't be a PSObject
+    assert actual == expected
+
+
+def test_ps_bool_deserialize_extended():
+    # This just makes sure we don't choke on an extended primitive bool and we still get the raw value back.
+    xml_val = '<Obj RefId="0"><B>true</B><MS><I32 N="Test Property">1</I32></MS></Obj>'
+    element = ET.fromstring(xml_val)
+
+    actual = SerializerV2().deserialize(element)
+    assert isinstance(actual, dotnet.PSBool)
+    assert isinstance(actual, bool)
+    assert not isinstance(actual, dotnet.PSObject)
+    assert actual is True


### PR DESCRIPTION
Started to implement the new and improved serializer for pypsrp. The main goals of this PR are

* Provide an easy translation layer for all the PS primitive types to a native Python type
* Provide a more transparent translation between complex objects and .NET objects
* Allow end users to easily implement their own types for use with serialization and deserialization
* Document this some more and provide better examples and tooling
* Improve tests for these scenarios to hopefully tease out edge cases

The new interface will be incompatible with the objects used in `pypsrp.complex_objects`. For backwards compatibility the default will be to use the older serializer so existing scripts won't break but users can easily opt in to the newer standard. The end goal is to get rid of the older serializer but that won't happen until V2 has been in place side by side in a proper release for some time and we can start warning people to use the newer version.