### PR TITLE
Handle warnings sent to the runspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,14 @@
 ### Features
 
 * Support endpoints that only have `Kerberos` enabled and not just `Negotiate`.
-* On Linux, use Kerberos if the `auto` auth provider is specified and no username or password is set. There is still no `NTLM` fallback but `Kerberos` is ideal in this scenario.
 * `Client.copy()` and `Client.fetch()` methods have new `expand_variables` parameter. This can be used to expand variables both in local and remote path.
 * Changed authentication library for `Kerberos` and `NTLM` auth to [pyspnego](https://github.com/jborean93/pyspnego).
+
+### Bugfixes
+
+* On Linux, use Kerberos if the `auto` auth provider is specified and no username or password is set. There is still no `NTLM` fallback but `Kerberos` is ideal in this scenario.
 * Use SHA256 when calculating the channel bindings token hash if an unknown algorithm is encountered.
+* Handle warning messages that are sent to the RunspacePool instead of raising an exception.
 
 
 ## 0.4.0 - 2019-09-19

--- a/pypsrp/powershell.py
+++ b/pypsrp/powershell.py
@@ -761,7 +761,7 @@ class RunspacePool(object):
         return message.data
 
     def _process_runspacepool_warning(self, message):
-        warnings.warn("RunspacePool warning: %s" % str(message.data), RunspacePoolWarning)
+        warnings.warn(str(message.data), RunspacePoolWarning)
 
     def _process_application_private_data(self, message):
         self._application_private_data = message.data


### PR DESCRIPTION
It turns out that a warning message can be sent to a runspace and not just a pipeline. Because we failed hard when an unknown/unsupported message was received before this would cause a failure. This change implements the warning handler so that any warnings are issued to `warnings.warn()`. It also handles unsupported message types a bit more gracefully in case more messages pop up in the future.

Will need to double check this fixes the issue when connecting to Exchange Online.

Fixes https://github.com/jborean93/pypsrp/issues/70
Fixes https://github.com/jborean93/pypsrp/issues/71
