### PR TITLE
added context managers for Client and WSMan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Support endpoints that only have `Kerberos` enabled and not just `Negotiate`.
 * `Client.copy()` and `Client.fetch()` methods have new `expand_variables` parameter. This can be used to expand variables both in local and remote path.
 * Changed authentication library for `Kerberos` and `NTLM` auth to [pyspnego](https://github.com/jborean93/pyspnego).
+* Added a context manager for `pypsrp.client.Client` and `pypsrp.wsman.WSMan`. This ensures any resources that the transport utilises will be closed if possible
 
 ### Bugfixes
 

--- a/README.md
+++ b/README.md
@@ -295,27 +295,27 @@ How to use the high level client API
 from pypsrp.client import Client
 
 # this takes in the same kwargs as the WSMan object
-client = Client("server", username="user", password="password")
+with Client("server", username="user", password="password") as client:
 
-# execute a cmd command
-stdout, stderr, rc = client.execute_cmd("dir")
-
-stdout, stderr, rc = client.execute_cmd("powershell.exe gci $pwd")
-sanitised_stderr = client.sanitise_clixml(stderr)
-
-# execute a PowerShell script
-output, streams, had_errors = client.execute_ps('''$path = "%s"
+    # execute a cmd command
+    stdout, stderr, rc = client.execute_cmd("dir")
+    
+    stdout, stderr, rc = client.execute_cmd("powershell.exe gci $pwd")
+    sanitised_stderr = client.sanitise_clixml(stderr)
+    
+    # execute a PowerShell script
+    output, streams, had_errors = client.execute_ps('''$path = "%s"
 if (Test-Path -Path $path) {
     Remove-Item -Path $path -Force -Recurse
 }
 New-Item -Path $path -ItemType Directory''' % path)
-output, streams, had_errors = client.execute_ps("New-Item -Path C:\\temp\\folder -ItemType Directory")
-
-# copy a file from the local host to the remote host
-client.copy("~/file.txt", "C:\\temp\\file.txt")
-
-# fetch a file from the remote host to the local host
-client.fetch("C:\\temp\\file.txt", "~/file.txt")
+    output, streams, had_errors = client.execute_ps("New-Item -Path C:\\temp\\folder -ItemType Directory")
+    
+    # copy a file from the local host to the remote host
+    client.copy("~/file.txt", "C:\\temp\\file.txt")
+    
+    # fetch a file from the remote host to the local host
+    client.fetch("C:\\temp\\file.txt", "~/file.txt")
 ```
 
 How to use WinRS/Process to execute a command
@@ -329,7 +329,7 @@ from pypsrp.wsman import WSMan
 wsman = WSMan("server", ssl=False, auth="basic", encryption="never",
               username="vagrant", password="vagrant")
 
-with WinRS(wsman) as shell:
+with wsman, WinRS(wsman) as shell:
     process = Process(shell, "dir")
     process.invoke()
     process.signal(SignalCode.CTRL_C)
@@ -351,7 +351,7 @@ from pypsrp.wsman import WSMan
 # creates a https connection with explicit kerberos auth and implicit credentials
 wsman = WSMan("server", auth="kerberos", cert_validation=False))
 
-with RunspacePool(wsman) as pool:
+with wsman, RunspacePool(wsman) as pool:
     # execute 'Get-Process | Select-Object Name'
     ps = PowerShell(pool)
     ps.add_cmdlet("Get-Process").add_cmdlet("Select-Object").add_argument("Name")

--- a/pypsrp/client.py
+++ b/pypsrp/client.py
@@ -51,6 +51,12 @@ class Client(object):
         """
         self.wsman = WSMan(server, **kwargs)
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.close()
+
     def copy(self, src, dest, configuration_name=DEFAULT_CONFIGURATION_NAME,
              expand_variables=False):
         """

--- a/pypsrp/wsman.py
+++ b/pypsrp/wsman.py
@@ -242,6 +242,12 @@ class WSMan(object):
         # this information for you.
         self.max_payload_size = self._calc_envelope_size(max_envelope_size)
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.close()
+
     def command(self, resource_uri, resource, option_set=None,
                 selector_set=None, timeout=None):
         res = self.invoke(WSManAction.COMMAND, resource_uri, resource,
@@ -703,7 +709,8 @@ class _TransportHTTP(object):
         # self._test_messages = []
 
     def close(self):
-        self.session.close()
+        if self.session:
+            self.session.close()
 
     def send(self, message):
         hostname = get_hostname(self.endpoint)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,6 +78,9 @@ class TransportFake(object):
         else:
             self._test_msg_key = "messages"
 
+    def close(self):
+        return
+
     def send(self, message):
         current_msg = self._test_meta[self._test_msg_key][self._msg_counter]
         actual = self._normalise_xml(message, generify=False,
@@ -317,7 +320,9 @@ def wsman_conn(request, monkeypatch):
                                   "password", ssl, "wsman", auth)
         wsman = WSMan("")
         wsman.transport = transport
-    yield wsman
+
+    with wsman:
+        yield wsman
 
     # used as an easy way to be results for a test, requires the _test_messages
     # to be uncommented in pypsrp/wsman.py

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -78,7 +78,7 @@ class TestPowerShellFunctional(object):
 
     def test_winrs(self, functional_transports):
         for wsman in functional_transports:
-            with WinRS(wsman) as shell:
+            with wsman, WinRS(wsman) as shell:
                 process = Process(shell, "echo", ["hi"])
                 process.invoke()
                 process.signal(SignalCode.CTRL_C)
@@ -88,7 +88,7 @@ class TestPowerShellFunctional(object):
 
     def test_psrp(self, functional_transports):
         for wsman in functional_transports:
-            with RunspacePool(wsman) as pool:
+            with wsman, RunspacePool(wsman) as pool:
                 pool.exchange_keys()
                 ps = PowerShell(pool)
                 ps.add_cmdlet("Get-Item").add_parameter("Path", "C:\\Windows")
@@ -125,7 +125,7 @@ class TestPowerShellFunctional(object):
 
     def test_psrp_jea(self, functional_transports):
         for wsman in functional_transports:
-            with RunspacePool(wsman, configuration_name="JEARole") as pool:
+            with wsman, RunspacePool(wsman, configuration_name="JEARole") as pool:
                 ps = PowerShell(pool)
                 wsman_path = "WSMan:\\localhost\\Service\\AllowUnencrypted"
                 ps.add_cmdlet("Get-Item").add_parameter("Path", wsman_path)


### PR DESCRIPTION
Extension of https://github.com/jborean93/pypsrp/pull/79.

Allows you to do the following to ensure the underlying transport is closed.

```python
with Client("server", username="user", password="password") as client:
    client.execute_cmd("echo test")
```