### PR TITLE
Settings proxy to false to ensure when ansible_psrp_ignore_proxy: yes doesn't use any proxies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.6.1 - TBD
+
+* Fix `no_proxy` to actually ignore environment proxy settings
+
+
 ## 0.6.0 - 2021-10-21
 
 ### Breaking changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pypsrp"
-version = "0.6.0"
+version = "0.6.1"
 description = "PowerShell Remoting Protocol and WinRM for Python"
 authors = ["Jordan Borean <jborean93@gmail.com>"]
 license = "MIT"

--- a/pypsrp/wsman.py
+++ b/pypsrp/wsman.py
@@ -807,19 +807,16 @@ class _TransportHTTP(object):
                                                       cert=None)
 
         # set the proxy config
-        orig_proxy = session.proxies
         session.proxies = settings['proxies']
+        proxy_key = 'https' if self.ssl else 'http'
         if self.proxy is not None:
-            proxy_key = 'https' if self.ssl else 'http'
             session.proxies = {
-                proxy_key: self.proxy
+                proxy_key: self.proxy,
             }
         elif self.no_proxy:
             session.proxies = {
-                'https': False
-            }
-        else:
-            session.proxies = orig_proxy
+                proxy_key: False,
+                }
 
         # Retry on connection errors, with a backoff factor
         retry_kwargs = {

--- a/pypsrp/wsman.py
+++ b/pypsrp/wsman.py
@@ -815,6 +815,10 @@ class _TransportHTTP(object):
                 proxy_key: self.proxy
             }
         elif self.no_proxy:
+            session.proxies = {
+                'https': False
+            }
+        else:
             session.proxies = orig_proxy
 
         # Retry on connection errors, with a backoff factor

--- a/tests/test_wsman.py
+++ b/tests/test_wsman.py
@@ -1004,8 +1004,7 @@ class TestTransportHTTP(object):
             session = transport._build_session()
         finally:
             del os.environ['https_proxy']
-        assert 'http' not in session.proxies
-        assert 'https' not in session.proxies
+        assert session.proxies == {'https': False}
 
     def test_build_session_proxies_kwarg_ignore_no_proxy(self):
         transport = _TransportHTTP("server", proxy="https://kwargproxy",


### PR DESCRIPTION
setting ansible_psrp_ignore_proxy: to yes doesn't do what it says it should do.
It should connect directly to host with no Env proxies etc but it just sets sesssion.proxies to orig_proxies.