### PR TITLE
Add low-level value tagging option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+* Add `TaggedValue` which allows the marking of a value with a tag that controls which serialization routine to apply.
+
 ## 0.6.1 - 2021-11-19
 
 * Fix `no_proxy` to actually ignore environment proxy settings

--- a/pypsrp/serializer.py
+++ b/pypsrp/serializer.py
@@ -75,7 +75,11 @@ class Serializer(object):
 
         metadata = metadata or ObjectMeta()
         if metadata.tag == "*":
-            metadata.tag = self._get_tag_from_value(value)
+            if isinstance(value, TaggedValue):
+                metadata.tag = value.tag
+                value = value.value
+            else:
+                metadata.tag = self._get_tag_from_value(value)
 
         pack_function = {
             # primitive types
@@ -786,3 +790,9 @@ class Serializer(object):
         if meta is None:
             meta = ObjectMeta(name=key)
         self.serialize(obj, metadata=meta, parent=parent, clear=False)
+
+
+class TaggedValue(object):
+    def __init__(self, tag, value):
+        self.tag = tag
+        self.value = value

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -10,7 +10,7 @@ from queue import Queue, Empty
 from pypsrp.complex_objects import ComplexObject, GenericComplexObject, \
     ListMeta, ObjectMeta, StackMeta
 from pypsrp.exceptions import SerializationError
-from pypsrp.serializer import Serializer
+from pypsrp.serializer import Serializer, TaggedValue
 from pypsrp._utils import to_string, to_unicode
 
 
@@ -43,7 +43,8 @@ class TestSerializer(object):
         [False, "<B>false</B>"],
         [10.0323, "<Sg>10.0323</Sg>"],
         [uuid.UUID(bytes=b"\x00" * 16),
-         "<G>00000000-0000-0000-0000-000000000000</G>"]
+         "<G>00000000-0000-0000-0000-000000000000</G>"],
+        [TaggedValue("U32", 1), "<U32>1</U32>"]
     ])
     def test_serialize_primitives(self, data, expected):
         serializer = Serializer()

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -55,6 +55,8 @@ class TestSerializer(object):
         assert actual_xml == expected_xml
 
         deserial_actual = serializer.deserialize(actual)
+        if isinstance(data, TaggedValue):
+            data = data.value
         assert deserial_actual == data
 
     def test_serialize_byte_string_py3(self):


### PR DESCRIPTION
This is a stop-gap solution waiting for #81 – it provides a low-level interface to marking a value with a tag which is mapped during serialization to a specific type, e.g. "SS" for `SecureString`.