### PR TITLE
Sometimes "to_string" is None; convert to string gracefully

### DIFF
--- a/pypsrp/complex_objects.py
+++ b/pypsrp/complex_objects.py
@@ -110,7 +110,9 @@ class GenericComplexObject(ComplexObject):
         self.types = []
 
     def __str__(self):
-        return to_string(self.to_string)
+        return to_string(
+            self.to_string if self.to_string is not None else 'None'
+        )
 
 
 class Enum(ComplexObject):


### PR DESCRIPTION
This avoids an error trying to decode `None` in `pypsrp._utils.to_unicode`.