### PR TITLE
Quality of life improvements to 'Command' and 'CommandParameter' classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## FUTURE - TBD
 
+* The `CommandParameter` class now uses named keyword arguments
+* The `cmd` parameter for `Command` class is now a positional argument
 * Ensure each `ps.streams.error` entry contains a `MESSAGE_TYPE` value just like the other stream objects
 * Use a default of `None` if a complex custom object has no `ToString` property defined.
 

--- a/pypsrp/complex_objects.py
+++ b/pypsrp/complex_objects.py
@@ -526,15 +526,15 @@ class Pipeline(ComplexObject):
 
 class Command(ComplexObject):
 
-    def __init__(self, protocol_version="2.3", **kwargs):
+    def __init__(self, cmd=None, protocol_version="2.3", **kwargs):
         """
         [MS-PSRP] 2.2.3.12 Command
         https://msdn.microsoft.com/en-us/library/dd339976.aspx
 
+        :param cmd: The cmdlet or script to run
         :param protocol_version: The negotiated protocol version of the remote
             host. This determines what merge_* objects are added to the
             serialized xml.
-        :param cmd: The cmdlet or script to run
         :param is_script: Whether cmd is a script or not
         :param use_local_scope: Use local or global scope to invoke commands
         :param merge_my_result: Controls the behaviour of what stream to merge
@@ -606,8 +606,8 @@ class Command(ComplexObject):
             ])
         self._extended_properties = extended_properties
 
+        self.cmd = cmd
         self.protocol_version = protocol_version
-        self.cmd = kwargs.get("cmd")
         self.is_script = kwargs.get("is_script")
         self.use_local_scope = kwargs.get("use_local_scope")
 
@@ -637,7 +637,7 @@ class Command(ComplexObject):
 
 class CommandParameter(ComplexObject):
 
-    def __init__(self, **kwargs):
+    def __init__(self, name=None, value=None):
         """
         [MS-PSRP] 2.2.3.13 Command Parameter
         https://msdn.microsoft.com/en-us/library/dd359709.aspx
@@ -651,8 +651,8 @@ class CommandParameter(ComplexObject):
             ('name', ObjectMeta("S", name="N")),
             ('value', ObjectMeta(name="V")),
         )
-        self.name = kwargs.get('name')
-        self.value = kwargs.get('value')
+        self.name = name
+        self.value = value
 
 
 # The host default data is serialized quite differently from the normal rules

--- a/pypsrp/powershell.py
+++ b/pypsrp/powershell.py
@@ -852,8 +852,9 @@ class PowerShell(object):
         :param use_local_scope: Run the cmdlet under the local scope
         :return: The current PowerShell object with the cmdlet added
         """
-        command = Command(protocol_version=self.runspace_pool.protocol_version,
-                          cmd=cmdlet, is_script=False,
+        command = Command(cmdlet,
+                          protocol_version=self.runspace_pool.protocol_version,
+                          is_script=False,
                           use_local_scope=use_local_scope)
         self.commands.append(command)
         self._current_command = command
@@ -898,8 +899,8 @@ class PowerShell(object):
         :param use_local_scope: Run the script under the local scope
         :return: the current PowerShell instance with the command added
         """
-        command = Command(protocol_version=self.runspace_pool.protocol_version,
-                          cmd=script, is_script=True,
+        command = Command(script, protocol_version=self.runspace_pool.protocol_version,
+                          is_script=True,
                           use_local_scope=use_local_scope)
         self.commands.append(command)
         self._current_command = command


### PR DESCRIPTION
This makes it a little more ergonomic to create commands using the `Command` and `CommandParameter` classes.

There should be no backwards incompatibilities.