### PR TITLE
Extend the 'ToString' string fallback when unset to non-generic complex object

### DIFF
--- a/pypsrp/_utils.py
+++ b/pypsrp/_utils.py
@@ -28,6 +28,9 @@ def to_unicode(obj, encoding='utf-8'):
     :param encoding: The encoding to use
     :return: THe unicode string the was decoded
     """
+    if obj is None:
+        obj = str(None)
+
     if isinstance(obj, str):
         return obj
 

--- a/pypsrp/complex_objects.py
+++ b/pypsrp/complex_objects.py
@@ -110,9 +110,7 @@ class GenericComplexObject(ComplexObject):
         self.types = []
 
     def __str__(self):
-        return to_string(
-            self.to_string if self.to_string is not None else 'None'
-        )
+        return to_string(self.to_string)
 
 
 class Enum(ComplexObject):

--- a/tests/test_complex_objects.py
+++ b/tests/test_complex_objects.py
@@ -575,6 +575,7 @@ class TestPipeline(object):
             CommandParameter(name="Name", value="var"),
             CommandParameter(name="Value", value="abc")
         ]
+        assert str(command) == 'None'
 
         pipeline = Pipeline()
         pipeline.is_nested = False
@@ -599,6 +600,7 @@ class TestPipeline(object):
             CommandParameter(name="Name", value="var"),
             CommandParameter(name="Value", value="abc")
         ]
+        assert str(command1) == 'None'
 
         command2 = Command(protocol_version="2.2")
         command2.cmd = "Get-Variable"
@@ -607,10 +609,13 @@ class TestPipeline(object):
         command2.args = [
             CommandParameter(name="Name", value="var"),
         ]
+        assert str(command2) == 'None'
+
         command3 = Command(protocol_version="2.2")
         command3.cmd = "Write-Output"
         command3.is_script = False
         command3.use_local_scope = False
+        assert str(command3) == 'None'
 
         pipeline = Pipeline()
         pipeline.is_nested = False


### PR DESCRIPTION
E.g. `pypsrp.powershell.Command` – which should be safe to "serialize to a string" even if it makes no sense really.