### PR TITLE
Add black, isort, and mypy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+repos:
+- repo: https://github.com/psf/black
+  rev: 21.12b0
+  hooks:
+  - id: black
+
+- repo: https://github.com/PyCQA/isort
+  rev: 5.10.1
+  hooks:
+  - id: isort
+
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v0.931
+  hooks:
+  - id: mypy
+    additional_dependencies:
+    - types-cryptography
+    - types-requests
+    - types-PyYAML

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,14 +6,20 @@
     ],
     "files.trimTrailingWhitespace": true,
     "editor.trimAutoWhitespace": true,
+    "python.formatting.provider": "black",
+    "python.linting.mypyEnabled": true,
     "python.analysis.extraPaths": [
         "src",
     ],
-    "python.formatting.provider": "none",
     "python.testing.pytestArgs": [
         "tests",
         "-vv"
     ],
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,
+    "[python]": {
+        "editor.codeActionsOnSave": {
+            "source.organizeImports": true
+        },
+    },
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Ensure each `ps.streams.error` entry contains a `MESSAGE_TYPE` value just like the other stream objects
 * Use a default of `None` if a complex custom object has no `ToString` property defined.
 * Moved back to using `setuptools` instead of `poetry` as the build system
+* Added type annotations to most public classes and methods
 
 
 ## 0.7.0 - 2021-12-13

--- a/build_helpers/check-winrm.py
+++ b/build_helpers/check-winrm.py
@@ -1,10 +1,11 @@
 import os
 import time
+import typing
 
 from pypsrp.client import Client
 
 
-def test_winrm() -> None:
+def test_winrm() -> typing.Tuple[str, str, int]:
     server = os.environ["PYPSRP_SERVER"]
     username = os.environ["PYPSRP_USERNAME"]
     password = os.environ["PYPSRP_PASSWORD"]

--- a/build_helpers/lib.sh
+++ b/build_helpers/lib.sh
@@ -92,12 +92,9 @@ lib::sanity::run() {
         echo "::group::Running Sanity Checks"
     fi
 
-    python -m pycodestyle \
-        src/pypsrp \
-        --verbose \
-        --show-source \
-        --statistics \
-        --max-line-length 119
+    python -m black . --check
+    python -m isort . --check-only
+    python -m mypy .
 
     if [ x"${GITHUB_ACTIONS}" = "xtrue" ]; then
         echo "::endgroup::"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,55 @@
 requires = ["setuptools>=42.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
+[tool.black]
+line-length = 120
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | _build
+  | buck-out
+  | build
+  | dist
+)/
+'''
+
+[tool.isort]
+profile = "black"
+
+[tool.mypy]
+exclude = "build/"
+mypy_path = "$MYPY_CONFIG_FILE_DIR/src"
+show_error_codes = true
+show_column_numbers = true
+disallow_any_unimported = true
+disallow_untyped_calls = true
+disallow_incomplete_defs = true
+disallow_untyped_decorators = true
+no_implicit_reexport = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+
+[[tool.mypy.overrides]]
+module = "requests.packages.urllib3.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "requests_credssp"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "spnego.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "xmldiff"
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
 testpaths = "tests"
 junit_family = "xunit2"
@@ -25,5 +74,7 @@ passenv =
 
 [testenv:lint]
 commands =
-    python -m pycodestyle src/pypsrp --verbose --show-source --statistics --max-line-length 119
+    python -m black . --check
+    python -m isort . --check-only
+    python -m mypy .
 """

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,10 @@
+black
 build
 gssapi ; sys_platform != 'win32'
 krb5 ; sys_platform != 'win32'
+isort
+mypy
+pre-commit
 pycodestyle
 pytest
 pytest-cov
@@ -8,4 +12,7 @@ pytest-mock
 PyYAML
 requests-credssp
 tox
+types-cryptography
+types-requests
+types-PyYAML
 xmldiff

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ install_requires =
 where = src
 
 [options.package_data]
+pypsrp = py.typed
 pypsrp.pwsh_scripts = *.ps1
 
 [options.extras_require]

--- a/src/pypsrp/__init__.py
+++ b/src/pypsrp/__init__.py
@@ -5,21 +5,15 @@ import json
 import logging
 import logging.config
 import os
-
-try:
-    from logging import NullHandler
-except ImportError:  # pragma: no cover
-    class NullHandler(logging.Handler):
-        def emit(self, record):
-            pass
+from logging import NullHandler
 
 
-def _setup_logging(logger):
-    log_path = os.environ.get('PYPSRP_LOG_CFG', None)
+def _setup_logging(logger: logging.Logger) -> None:
+    log_path = os.environ.get("PYPSRP_LOG_CFG", None)
 
     if log_path is not None and os.path.exists(log_path):  # pragma: no cover
         # log log config from JSON file
-        with open(log_path, 'rt') as f:
+        with open(log_path, "rt") as f:
             config = json.load(f)
 
         logging.config.dictConfig(config)
@@ -34,7 +28,7 @@ _setup_logging(logger)
 # Contains a list of features, used by external libraries to determine whether
 # a new enough pypsrp is installed to support the features it needs
 FEATURES = [
-    'wsman_locale',
-    'wsman_read_timeout',
-    'wsman_reconnections',
+    "wsman_locale",
+    "wsman_read_timeout",
+    "wsman_reconnections",
 ]

--- a/src/pypsrp/_utils.py
+++ b/src/pypsrp/_utils.py
@@ -2,11 +2,14 @@
 # MIT License (see LICENSE or https://opensource.org/licenses/MIT)
 
 import pkgutil
-
+import typing
 from urllib.parse import urlparse
 
 
-def to_bytes(obj, encoding='utf-8'):
+def to_bytes(
+    obj: typing.Any,
+    encoding: str = "utf-8",
+) -> bytes:
     """
     Makes sure the string is encoded as a byte string.
 
@@ -20,7 +23,10 @@ def to_bytes(obj, encoding='utf-8'):
     return obj.encode(encoding)
 
 
-def to_unicode(obj, encoding='utf-8'):
+def to_unicode(
+    obj: typing.Any,
+    encoding: str = "utf-8",
+) -> str:
     """
     Makes sure the string is unicode string.
 
@@ -45,7 +51,10 @@ convert an existing string like object to the native version that is required
 to_string = to_unicode
 
 
-def version_equal_or_newer(version, reference_version):
+def version_equal_or_newer(
+    version: str,
+    reference_version: str,
+) -> bool:
     """
     Compares the 2 version strings and returns a bool that states whether
     version is newer than or equal to the reference version.
@@ -71,21 +80,21 @@ def version_equal_or_newer(version, reference_version):
 
     newer = True
     for idx, version in enumerate(version_parts):
-        reference_version = int(reference_version_parts[idx])
-        if int(version) < reference_version:
+        current_version = int(reference_version_parts[idx])
+        if int(version) < current_version:
             newer = False
             break
-        elif int(version) > reference_version:
+        elif int(version) > current_version:
             break
 
     return newer
 
 
-def get_hostname(url):
+def get_hostname(url: str) -> typing.Optional[str]:
     return urlparse(url).hostname
 
 
-def get_pwsh_script(name):
+def get_pwsh_script(name: str) -> str:
     """
     Get the contents of a script stored in pypsrp/pwsh_scripts. Will also strip out any empty lines and comments to
     reduce the data we send across as much as possible.
@@ -93,7 +102,7 @@ def get_pwsh_script(name):
     :param name: The filename of the script in pypsrp/pwsh_scripts to get.
     :return: The script contents.
     """
-    script = to_unicode(pkgutil.get_data('pypsrp.pwsh_scripts', name))
+    script = to_unicode(pkgutil.get_data("pypsrp.pwsh_scripts", name))
 
     block_comment = False
     new_lines = []
@@ -101,10 +110,10 @@ def get_pwsh_script(name):
 
         line = line.strip()
         if block_comment:
-            block_comment = not line.endswith('#>')
-        elif line.startswith('<#'):
+            block_comment = not line.endswith("#>")
+        elif line.startswith("<#"):
             block_comment = True
-        elif line and not line.startswith('#'):
+        elif line and not line.startswith("#"):
             new_lines.append(line)
 
-    return '\n'.join(new_lines)
+    return "\n".join(new_lines)

--- a/src/pypsrp/complex_objects.py
+++ b/src/pypsrp/complex_objects.py
@@ -1,14 +1,20 @@
 # Copyright: (c) 2018, Jordan Borean (@jborean93) <jborean93@gmail.com>
 # MIT License (see LICENSE or https://opensource.org/licenses/MIT)
 
+import typing
 from copy import deepcopy
 
 from pypsrp._utils import to_string, version_equal_or_newer
 
 
 class ObjectMeta(object):
-
-    def __init__(self, tag="*", name=None, optional=False, object=None):
+    def __init__(
+        self,
+        tag: str = "*",
+        name: typing.Optional[str] = None,
+        optional: bool = False,
+        object: typing.Any = None,
+    ) -> None:
         self.tag = tag
         self.name = name
         self.optional = optional
@@ -16,9 +22,14 @@ class ObjectMeta(object):
 
 
 class ListMeta(ObjectMeta):
-
-    def __init__(self, obj_type="LST", name=None, optional=False,
-                 list_value_meta=None, list_types=None):
+    def __init__(
+        self,
+        obj_type: str = "LST",
+        name: typing.Optional[str] = None,
+        optional: bool = False,
+        list_value_meta: typing.Optional[ObjectMeta] = None,
+        list_types: typing.Optional[typing.List[str]] = None,
+    ) -> None:
         super(ListMeta, self).__init__(obj_type, name, optional)
 
         if list_value_meta is None:
@@ -27,44 +38,46 @@ class ListMeta(ObjectMeta):
             self.list_value_meta = list_value_meta
 
         if list_types is None:
-            self.list_types = [
-                "System.Object[]",
-                "System.Array",
-                "System.Object"
-            ]
+            self.list_types = ["System.Object[]", "System.Array", "System.Object"]
         else:
             self.list_types = list_types
 
 
 class StackMeta(ListMeta):
-
-    def __init__(self, name=None, optional=False, list_value_meta=None,
-                 list_types=None):
+    def __init__(
+        self,
+        name: typing.Optional[str] = None,
+        optional: bool = False,
+        list_value_meta: typing.Optional[ObjectMeta] = None,
+        list_types: typing.Optional[typing.List[str]] = None,
+    ) -> None:
         if list_types is None:
-            list_types = [
-                "System.Collections.Stack",
-                "System.Object"
-            ]
-        super(StackMeta, self).__init__("STK", name, optional, list_value_meta,
-                                        list_types)
+            list_types = ["System.Collections.Stack", "System.Object"]
+        super(StackMeta, self).__init__("STK", name, optional, list_value_meta, list_types)
 
 
 class QueueMeta(ListMeta):
-    def __init__(self, name=None, optional=False, list_value_meta=None,
-                 list_types=None):
+    def __init__(
+        self,
+        name: typing.Optional[str] = None,
+        optional: bool = False,
+        list_value_meta: typing.Optional[ObjectMeta] = None,
+        list_types: typing.Optional[typing.List[str]] = None,
+    ) -> None:
         if list_types is None:
-            list_types = [
-                "System.Collections.Queue",
-                "System.Object"
-            ]
-        super(QueueMeta, self).__init__("QUE", name, optional, list_value_meta,
-                                        list_types)
+            list_types = ["System.Collections.Queue", "System.Object"]
+        super(QueueMeta, self).__init__("QUE", name, optional, list_value_meta, list_types)
 
 
 class DictionaryMeta(ObjectMeta):
-
-    def __init__(self, name=None, optional=False, dict_key_meta=None,
-                 dict_value_meta=None, dict_types=None):
+    def __init__(
+        self,
+        name: typing.Optional[str] = None,
+        optional: bool = False,
+        dict_key_meta: typing.Optional[ObjectMeta] = None,
+        dict_value_meta: typing.Optional[ObjectMeta] = None,
+        dict_types: typing.Optional[typing.List[str]] = None,
+    ) -> None:
         super(DictionaryMeta, self).__init__("DCT", name, optional)
         if dict_key_meta is None:
             self.dict_key_meta = ObjectMeta(name="Key")
@@ -77,78 +90,74 @@ class DictionaryMeta(ObjectMeta):
             self.dict_value_meta = dict_value_meta
 
         if dict_types is None:
-            self.dict_types = [
-                "System.Collections.Hashtable",
-                "System.Object"
-            ]
+            self.dict_types = ["System.Collections.Hashtable", "System.Object"]
         else:
             self.dict_types = dict_types
 
 
 class ComplexObject(object):
-
-    def __init__(self):
-        self._adapted_properties = ()
-        self._extended_properties = ()
-        self._property_sets = ()
-        self._types = []
+    def __init__(self) -> None:
+        self._adapted_properties: typing.Tuple[typing.Tuple[str, ObjectMeta], ...] = ()
+        self._extended_properties: typing.Tuple[typing.Tuple[str, ObjectMeta], ...] = ()
+        self._property_sets: typing.Tuple[typing.Tuple[str, ObjectMeta], ...] = ()
+        self._types: typing.List[str] = []
         self._to_string = None
-        self._xml = None  # only populated on deserialization
+        self._xml: typing.Optional[str] = None  # only populated on deserialization
 
-    def __str__(self):
+    def __str__(self) -> str:
         return to_string(self._to_string)
 
 
 class GenericComplexObject(ComplexObject):
-
-    def __init__(self):
+    def __init__(self) -> None:
         super(GenericComplexObject, self).__init__()
-        self.property_sets = []
-        self.extended_properties = {}
-        self.adapted_properties = {}
-        self.to_string = None
-        self.types = []
+        self.property_sets: typing.List[typing.Any] = []
+        self.extended_properties: typing.Dict[str, typing.Any] = {}
+        self.adapted_properties: typing.Dict[str, typing.Any] = {}
+        self.to_string: typing.Optional[str] = None
+        self.types: typing.List[str] = []
 
-    def __str__(self):
+    def __str__(self) -> str:
         return to_string(self.to_string)
 
 
 class Enum(ComplexObject):
-
-    def __init__(self, enum_type, string_map, **kwargs):
+    def __init__(
+        self,
+        enum_type: typing.Optional[str],
+        string_map: typing.Dict[int, str],
+        **kwargs: typing.Any,
+    ) -> None:
         super(Enum, self).__init__()
-        self._types = [
-            "System.Enum",
-            "System.ValueType",
-            "System.Object"
-        ]
+        self._types = ["System.Enum", "System.ValueType", "System.Object"]
         if enum_type is not None:
             self._types.insert(0, enum_type)
 
-        self._property_sets = (
-            ('value', ObjectMeta("I32")),
-        )
+        self._property_sets = (("value", ObjectMeta("I32")),)
         self._string_map = string_map
 
-        self.value = kwargs.get('value')
+        self.value = kwargs.get("value")
 
-    @property
-    def _to_string(self):
+    @property  # type: ignore[override]
+    def _to_string(self) -> str:  # type: ignore[override]
         try:
-            return self._string_map[self.value]
+            return self._string_map[self.value or 0]
         except KeyError as err:
-            raise KeyError("%s is not a valid enum value for %s, valid values "
-                           "are %s" % (err, self._types[0], self._string_map))
+            raise KeyError(
+                "%s is not a valid enum value for %s, valid values are %s" % (err, self._types[0], self._string_map)
+            )
 
     @_to_string.setter
-    def _to_string(self, value):
+    def _to_string(self, value: str) -> None:
         pass
 
 
 # PSRP Complex Objects - https://msdn.microsoft.com/en-us/library/dd302883.aspx
 class Coordinates(ComplexObject):
-
-    def __init__(self, **kwargs):
+    def __init__(
+        self,
+        **kwargs: typing.Any,
+    ) -> None:
         """
         [MS-PSRP] 2.2.3.1 Coordinates
         https://msdn.microsoft.com/en-us/library/dd302883.aspx
@@ -158,21 +167,16 @@ class Coordinates(ComplexObject):
         """
         super(Coordinates, self).__init__()
         self._adapted_properties = (
-            ('x', ObjectMeta("I32", name="X")),
-            ('y', ObjectMeta("I32", name="Y")),
+            ("x", ObjectMeta("I32", name="X")),
+            ("y", ObjectMeta("I32", name="Y")),
         )
-        self._types = [
-            "System.Management.Automation.Host.Coordinates",
-            "System.ValueType",
-            "System.Object"
-        ]
-        self.x = kwargs.get('x')
-        self.y = kwargs.get('y')
+        self._types = ["System.Management.Automation.Host.Coordinates", "System.ValueType", "System.Object"]
+        self.x = kwargs.get("x")
+        self.y = kwargs.get("y")
 
 
 class Size(ComplexObject):
-
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs: typing.Any) -> None:
         """
         [MS-PSRP] 2.2.3.2 Size
         https://msdn.microsoft.com/en-us/library/dd305083.aspx
@@ -182,16 +186,12 @@ class Size(ComplexObject):
         """
         super(Size, self).__init__()
         self._adapted_properties = (
-            ('width', ObjectMeta("I32", name="Width")),
-            ('height', ObjectMeta("I32", name="Height")),
+            ("width", ObjectMeta("I32", name="Width")),
+            ("height", ObjectMeta("I32", name="Height")),
         )
-        self._types = [
-            "System.Management.Automation.Host.Size",
-            "System.ValueType",
-            "System.Object"
-        ]
-        self.width = kwargs.get('width')
-        self.height = kwargs.get('height')
+        self._types = ["System.Management.Automation.Host.Size", "System.ValueType", "System.Object"]
+        self.width = kwargs.get("width")
+        self.height = kwargs.get("height")
 
 
 class Color(Enum):
@@ -212,7 +212,10 @@ class Color(Enum):
     YELLOW = 14
     WHITE = 15
 
-    def __init__(self, **kwargs):
+    def __init__(
+        self,
+        **kwargs: typing.Any,
+    ) -> None:
         """
         [MS-PSRP] 2.2.3.3 Color
         https://msdn.microsoft.com/en-us/library/dd360026.aspx
@@ -237,8 +240,7 @@ class Color(Enum):
             14: "Yellow",
             15: "White",
         }
-        super(Color, self).__init__("System.ConsoleColor", string_map,
-                                    **kwargs)
+        super(Color, self).__init__("System.ConsoleColor", string_map, **kwargs)
 
 
 class RunspacePoolState(object):
@@ -275,7 +277,7 @@ class RunspacePoolState(object):
             6: "NegotiationSent",
             7: "NegotiationSucceeded",
             8: "Connecting",
-            9: "Disconnected"
+            9: "Disconnected",
         }[self.state]
 
 
@@ -307,7 +309,7 @@ class PSInvocationState(object):
             3: "Stopped",
             4: "Completed",
             5: "Failed",
-            6: "Disconnected"
+            6: "Disconnected",
         }[self.state]
 
 
@@ -317,22 +319,19 @@ class PSThreadOptions(Enum):
     REUSE_THREAD = 2
     USE_CURRENT_THREAD = 3
 
-    def __init__(self, **kwargs):
+    def __init__(
+        self,
+        **kwargs: typing.Any,
+    ) -> None:
         """
         [MS-PSRP] 2.2.3.6 PSThreadOptions
         https://msdn.microsoft.com/en-us/library/dd305678.aspx
 
         :param value: The enum value for PS Thread Options
         """
-        string_map = {
-            0: "Default",
-            1: "UseNewThread",
-            2: "ReuseThread",
-            3: "UseCurrentThread"
-        }
+        string_map = {0: "Default", 1: "UseNewThread", 2: "ReuseThread", 3: "UseCurrentThread"}
         super(PSThreadOptions, self).__init__(
-            "System.Management.Automation.Runspaces.PSThreadOptions",
-            string_map, **kwargs
+            "System.Management.Automation.Runspaces.PSThreadOptions", string_map, **kwargs
         )
 
 
@@ -341,21 +340,19 @@ class ApartmentState(Enum):
     MTA = 1
     UNKNOWN = 2
 
-    def __init__(self, **kwargs):
+    def __init__(
+        self,
+        **kwargs: typing.Any,
+    ) -> None:
         """
         [MS-PSRP] 2.2.3.7 ApartmentState
         https://msdn.microsoft.com/en-us/library/dd304257.aspx
 
         :param value: The enum value for Apartment State
         """
-        string_map = {
-            0: 'STA',
-            1: 'MTA',
-            2: 'UNKNOWN'
-        }
+        string_map = {0: "STA", 1: "MTA", 2: "UNKNOWN"}
         super(ApartmentState, self).__init__(
-            "System.Management.Automation.Runspaces.ApartmentState",
-            string_map, **kwargs
+            "System.Management.Automation.Runspaces.ApartmentState", string_map, **kwargs
         )
 
 
@@ -366,7 +363,10 @@ class RemoteStreamOptions(Enum):
     ADD_INVOCATION_INFO_TO_VERBOSE_RECORD = 8
     ADD_INVOCATION_INFO = 15
 
-    def __init__(self, **kwargs):
+    def __init__(
+        self,
+        **kwargs: typing.Any,
+    ) -> None:
         """
         [MS-PSRP] 2.2.3.8 RemoteStreamOptions
         https://msdn.microsoft.com/en-us/library/dd303829.aspx
@@ -374,12 +374,11 @@ class RemoteStreamOptions(Enum):
         :param value: The initial RemoteStreamOption to set
         """
         super(RemoteStreamOptions, self).__init__(
-            "System.Management.Automation.Runspaces.RemoteStreamOptions",
-            {}, **kwargs
+            "System.Management.Automation.Runspaces.RemoteStreamOptions", {}, **kwargs
         )
 
-    @property
-    def _to_string(self):
+    @property  # type: ignore[override]
+    def _to_string(self) -> str:  # type: ignore[override]
         if self.value == 15:
             return "AddInvocationInfo"
 
@@ -391,7 +390,7 @@ class RemoteStreamOptions(Enum):
         )
         values = []
         for name, flag in string_map:
-            if self.value & flag == flag:
+            if (self.value or 0) & flag == flag:
                 values.append(name)
         return ", ".join(values)
 
@@ -401,27 +400,32 @@ class RemoteStreamOptions(Enum):
 
 
 class Pipeline(ComplexObject):
-
     class _ExtraCmds(ComplexObject):
         def __init__(self, **kwargs):
             # Used to encapsulate ExtraCmds in the structure required
             super(Pipeline._ExtraCmds, self).__init__()
             self._extended_properties = (
-                ('cmds', ListMeta(
-                    name="Cmds",
-                    list_value_meta=ObjectMeta("Obj", object=Command),
-                    list_types=[
-                        "System.Collections.Generic.List`1[["
-                        "System.Management.Automation.PSObject, "
-                        "System.Management.Automation, Version=1.0.0.0, "
-                        "Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-                        "System.Object",
-                    ]
-                )),
+                (
+                    "cmds",
+                    ListMeta(
+                        name="Cmds",
+                        list_value_meta=ObjectMeta("Obj", object=Command),
+                        list_types=[
+                            "System.Collections.Generic.List`1[["
+                            "System.Management.Automation.PSObject, "
+                            "System.Management.Automation, Version=1.0.0.0, "
+                            "Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+                            "System.Object",
+                        ],
+                    ),
+                ),
             )
-            self.cmds = kwargs.get('cmds')
+            self.cmds = kwargs.get("cmds")
 
-    def __init__(self, **kwargs):
+    def __init__(
+        self,
+        **kwargs: typing.Any,
+    ) -> None:
         """
         [MS-PSRP] 2.2.3.11 Pipeline
         https://msdn.microsoft.com/en-us/library/dd358182.aspx
@@ -443,26 +447,23 @@ class Pipeline(ComplexObject):
         ]
 
         self._extended_properties = (
-            ('is_nested', ObjectMeta("B", name="IsNested")),
+            ("is_nested", ObjectMeta("B", name="IsNested")),
             # ExtraCmds isn't in spec but is value and used to send multiple
             # statements
-            ('_extra_cmds', ListMeta(
-                name="ExtraCmds",
-                list_value_meta=ObjectMeta("Obj", object=self._ExtraCmds),
-                list_types=cmd_types
-            )),
-            ('_cmds', ListMeta(
-                name="Cmds", list_value_meta=ObjectMeta("Obj", object=Command),
-                list_types=cmd_types
-            )),
-            ('history', ObjectMeta("S", name="History")),
-            ('redirect_err_to_out',
-             ObjectMeta("B", name="RedirectShellErrorOutputPipe")),
+            (
+                "_extra_cmds",
+                ListMeta(
+                    name="ExtraCmds", list_value_meta=ObjectMeta("Obj", object=self._ExtraCmds), list_types=cmd_types
+                ),
+            ),
+            ("_cmds", ListMeta(name="Cmds", list_value_meta=ObjectMeta("Obj", object=Command), list_types=cmd_types)),
+            ("history", ObjectMeta("S", name="History")),
+            ("redirect_err_to_out", ObjectMeta("B", name="RedirectShellErrorOutputPipe")),
         )
-        self.is_nested = kwargs.get('is_nested')
-        self.commands = kwargs.get('cmds')
-        self.history = kwargs.get('history')
-        self.redirect_err_to_out = kwargs.get('redirect_err_to_out')
+        self.is_nested = kwargs.get("is_nested")
+        self.commands = kwargs.get("cmds")
+        self.history = kwargs.get("history")
+        self.redirect_err_to_out = kwargs.get("redirect_err_to_out")
 
     @property
     def _cmds(self):
@@ -523,8 +524,12 @@ class Pipeline(ComplexObject):
 
 
 class Command(ComplexObject):
-
-    def __init__(self, cmd=None, protocol_version="2.3", **kwargs):
+    def __init__(
+        self,
+        cmd: typing.Optional[str] = None,
+        protocol_version: str = "2.3",
+        **kwargs: typing.Any,
+    ) -> None:
         """
         [MS-PSRP] 2.2.3.12 Command
         https://msdn.microsoft.com/en-us/library/dd339976.aspx
@@ -562,47 +567,41 @@ class Command(ComplexObject):
             "System.Object",
         ]
         extended_properties = [
-            ('cmd', ObjectMeta("S", name="Cmd")),
-            ('is_script', ObjectMeta("B", name="IsScript")),
-            ('use_local_scope', ObjectMeta("B", name="UseLocalScope")),
-            ('merge_my_result', ObjectMeta("Obj", name="MergeMyResult",
-                                           object=PipelineResultTypes)),
-            ('merge_to_result', ObjectMeta("Obj", name="MergeToResult",
-                                           object=PipelineResultTypes)),
-            ('merge_previous', ObjectMeta("Obj", name="MergePreviousResults",
-                                          object=PipelineResultTypes)),
-            ('args', ListMeta(
-                name="Args",
-                list_value_meta=ObjectMeta(object=CommandParameter),
-                list_types=arg_types)
-             ),
+            ("cmd", ObjectMeta("S", name="Cmd")),
+            ("is_script", ObjectMeta("B", name="IsScript")),
+            ("use_local_scope", ObjectMeta("B", name="UseLocalScope")),
+            ("merge_my_result", ObjectMeta("Obj", name="MergeMyResult", object=PipelineResultTypes)),
+            ("merge_to_result", ObjectMeta("Obj", name="MergeToResult", object=PipelineResultTypes)),
+            ("merge_previous", ObjectMeta("Obj", name="MergePreviousResults", object=PipelineResultTypes)),
+            ("args", ListMeta(name="Args", list_value_meta=ObjectMeta(object=CommandParameter), list_types=arg_types)),
         ]
 
         if version_equal_or_newer(protocol_version, "2.2"):
-            extended_properties.extend([
-                ('merge_error', ObjectMeta("Obj", name="MergeError",
-                                           object=PipelineResultTypes,
-                                           optional=True)),
-                ('merge_warning', ObjectMeta("Obj", name="MergeWarning",
-                                             object=PipelineResultTypes,
-                                             optional=True)),
-                ('merge_verbose', ObjectMeta("Obj", name="MergeVerbose",
-                                             object=PipelineResultTypes,
-                                             optional=True)),
-                ('merge_debug', ObjectMeta("Obj", name="MergeDebug",
-                                           object=PipelineResultTypes,
-                                           optional=True)),
-            ])
+            extended_properties.extend(
+                [
+                    ("merge_error", ObjectMeta("Obj", name="MergeError", object=PipelineResultTypes, optional=True)),
+                    (
+                        "merge_warning",
+                        ObjectMeta("Obj", name="MergeWarning", object=PipelineResultTypes, optional=True),
+                    ),
+                    (
+                        "merge_verbose",
+                        ObjectMeta("Obj", name="MergeVerbose", object=PipelineResultTypes, optional=True),
+                    ),
+                    ("merge_debug", ObjectMeta("Obj", name="MergeDebug", object=PipelineResultTypes, optional=True)),
+                ]
+            )
 
         if version_equal_or_newer(protocol_version, "2.3"):
-            extended_properties.extend([
-                ('merge_information', ObjectMeta(
-                    "Obj", name="MergeInformation",
-                    object=PipelineResultTypes,
-                    optional=True
-                )),
-            ])
-        self._extended_properties = extended_properties
+            extended_properties.extend(
+                [
+                    (
+                        "merge_information",
+                        ObjectMeta("Obj", name="MergeInformation", object=PipelineResultTypes, optional=True),
+                    ),
+                ]
+            )
+        self._extended_properties = tuple(extended_properties)
 
         self.cmd = cmd
         self.protocol_version = protocol_version
@@ -634,8 +633,11 @@ class Command(ComplexObject):
 
 
 class CommandParameter(ComplexObject):
-
-    def __init__(self, name=None, value=None):
+    def __init__(
+        self,
+        name: typing.Optional[str] = None,
+        value: typing.Any = None,
+    ) -> None:
         """
         [MS-PSRP] 2.2.3.13 Command Parameter
         https://msdn.microsoft.com/en-us/library/dd359709.aspx
@@ -646,8 +648,8 @@ class CommandParameter(ComplexObject):
         """
         super(CommandParameter, self).__init__()
         self._extended_properties = (
-            ('name', ObjectMeta("S", name="N")),
-            ('value', ObjectMeta(name="V")),
+            ("name", ObjectMeta("S", name="N")),
+            ("value", ObjectMeta(name="V")),
         )
         self.name = name
         self.value = value
@@ -656,67 +658,57 @@ class CommandParameter(ComplexObject):
 # The host default data is serialized quite differently from the normal rules
 # this contains some sub classes that are specific to the serialized form
 class _HostDefaultData(ComplexObject):
-
     class _DictValue(ComplexObject):
-
         def __init__(self, **kwargs):
             super(_HostDefaultData._DictValue, self).__init__()
             self._extended_properties = (
-                ('value_type', ObjectMeta("S", name="T")),
-                ('value', ObjectMeta(name="V")),
+                ("value_type", ObjectMeta("S", name="T")),
+                ("value", ObjectMeta(name="V")),
             )
-            self.value_type = kwargs.get('value_type')
-            self.value = kwargs.get('value')
+            self.value_type = kwargs.get("value_type")
+            self.value = kwargs.get("value")
 
     class _Color(ComplexObject):
-
         def __init__(self, color):
             super(_HostDefaultData._Color, self).__init__()
             self._extended_properties = (
-                ('type', ObjectMeta("S", name="T")),
-                ('color', ObjectMeta("I32", name="V")),
+                ("type", ObjectMeta("S", name="T")),
+                ("color", ObjectMeta("I32", name="V")),
             )
             self.type = "System.ConsoleColor"
             self.color = color.value
 
     class _Coordinates(ComplexObject):
-
         def __init__(self, coordinates):
             super(_HostDefaultData._Coordinates, self).__init__()
             self._extended_properties = (
-                ('type', ObjectMeta("S", name="T")),
-                ('value', ObjectMeta("ObjDynamic", name="V",
-                                     object=GenericComplexObject)),
+                ("type", ObjectMeta("S", name="T")),
+                ("value", ObjectMeta("ObjDynamic", name="V", object=GenericComplexObject)),
             )
             self.type = "System.Management.Automation.Host.Coordinates"
             self.value = GenericComplexObject()
-            self.value.extended_properties['x'] = coordinates.x
-            self.value.extended_properties['y'] = coordinates.y
+            self.value.extended_properties["x"] = coordinates.x
+            self.value.extended_properties["y"] = coordinates.y
 
     class _Size(ComplexObject):
-
         def __init__(self, size):
             super(_HostDefaultData._Size, self).__init__()
             self._extended_properties = (
-                ('type', ObjectMeta("S", name="T")),
-                ('value', ObjectMeta("ObjDynamic", name="V",
-                                     object=GenericComplexObject)),
+                ("type", ObjectMeta("S", name="T")),
+                ("value", ObjectMeta("ObjDynamic", name="V", object=GenericComplexObject)),
             )
             self.type = "System.Management.Automation.Host.Size"
             self.value = GenericComplexObject()
-            self.value.extended_properties['width'] = size.width
-            self.value.extended_properties['height'] = size.height
+            self.value.extended_properties["width"] = size.width
+            self.value.extended_properties["height"] = size.height
 
     def __init__(self, **kwargs):
         # Used by HostInfo to encapsulate the host info values inside a
         # special object required by PSRP
         super(_HostDefaultData, self).__init__()
         key_meta = ObjectMeta("I32", name="Key")
-        self._extended_properties = (
-            ('_host_dict', DictionaryMeta(name="data",
-                                          dict_key_meta=key_meta)),
-        )
-        self.raw_ui = kwargs.get('raw_ui')
+        self._extended_properties = (("_host_dict", DictionaryMeta(name="data", dict_key_meta=key_meta)),)
+        self.raw_ui = kwargs.get("raw_ui")
 
     @property
     def _host_dict(self):
@@ -725,20 +717,20 @@ class _HostDefaultData(ComplexObject):
             (1, self._Color(self.raw_ui.background_color)),
             (2, self._Coordinates(self.raw_ui.cursor_position)),
             (3, self._Coordinates(self.raw_ui.window_position)),
-            (4, self._DictValue(value_type="System.Int32",
-                                value=self.raw_ui.cursor_size)),
+            (4, self._DictValue(value_type="System.Int32", value=self.raw_ui.cursor_size)),
             (5, self._Size(self.raw_ui.buffer_size)),
             (6, self._Size(self.raw_ui.window_size)),
             (7, self._Size(self.raw_ui.max_window_size)),
             (8, self._Size(self.raw_ui.max_physical_window_size)),
-            (9, self._DictValue(value_type="System.String",
-                                value=self.raw_ui.window_title)),
+            (9, self._DictValue(value_type="System.String", value=self.raw_ui.window_title)),
         )
 
 
 class HostInfo(ComplexObject):
-
-    def __init__(self, **kwargs):
+    def __init__(
+        self,
+        **kwargs: typing.Any,
+    ) -> None:
         """
         [MS-PSRP] 2.2.3.14 HostInfo
         https://msdn.microsoft.com/en-us/library/dd340936.aspx
@@ -748,14 +740,13 @@ class HostInfo(ComplexObject):
         """
         super(HostInfo, self).__init__()
         self._extended_properties = (
-            ('_host_data', ObjectMeta("Obj", name="_hostDefaultData",
-                                      optional=True, object=_HostDefaultData)),
-            ('_is_host_null', ObjectMeta("B", name="_isHostNull")),
-            ('_is_host_ui_null', ObjectMeta("B", name="_isHostUINull")),
-            ('_is_host_raw_ui_null', ObjectMeta("B", name="_isHostRawUINull")),
-            ('_use_runspace_host', ObjectMeta("B", name="_useRunspaceHost")),
+            ("_host_data", ObjectMeta("Obj", name="_hostDefaultData", optional=True, object=_HostDefaultData)),
+            ("_is_host_null", ObjectMeta("B", name="_isHostNull")),
+            ("_is_host_ui_null", ObjectMeta("B", name="_isHostUINull")),
+            ("_is_host_raw_ui_null", ObjectMeta("B", name="_isHostRawUINull")),
+            ("_use_runspace_host", ObjectMeta("B", name="_useRunspaceHost")),
         )
-        self.host = kwargs.get('host', None)
+        self.host = kwargs.get("host", None)
 
     @property
     def _is_host_null(self):
@@ -789,383 +780,281 @@ class HostInfo(ComplexObject):
 
 
 class ErrorRecord(ComplexObject):
-
     def __init__(self, **kwargs):
         """
         [MS-PSRP] 2.2.3.15 ErrorRecord
         https://msdn.microsoft.com/en-us/library/dd340106.aspx
         """
         super(ErrorRecord, self).__init__()
-        self._types = [
-            "System.Management.Automation.ErrorRecord",
-            "System.Object"
-        ]
+        self._types = ["System.Management.Automation.ErrorRecord", "System.Object"]
         self._extended_properties = (
-            ('exception', ObjectMeta(name="Exception", optional=True)),
-            ('target_object', ObjectMeta(name="TargetObject", optional=True)),
-            ('invocation', ObjectMeta("B", name="SerializeExtendedInfo")),
-            ('invocation_info', ObjectMeta("ObjDynamic", name="InvocationInfo",
-                                           object=GenericComplexObject,
-                                           optional=True)),
-            ('fq_error', ObjectMeta("S", name="FullyQualifiedErrorId")),
-            ('category', ObjectMeta("I32", name="ErrorCategory_Category")),
-            ('activity', ObjectMeta("S", name="ErrorCategory_Activity",
-                                    optional=True)),
-            ('reason', ObjectMeta("S", name="ErrorCategory_Reason",
-                                  optional=True)),
-            ('target_name', ObjectMeta("S", name="ErrorCategory_TargetName",
-                                       optional=True)),
-            ('target_type', ObjectMeta("S", name="ErrorCategory_TargetType",
-                                       optional=True)),
-            ('message', ObjectMeta("S", name="ErrorCategory_Message",
-                                   optional=True)),
-            ('details_message', ObjectMeta("S", name="ErrorDetails_Message",
-                                           optional=True)),
-            ('action', ObjectMeta("S", name="ErrorDetails_RecommendedAction",
-                                  optional=True)),
-            ('script_stacktrace', ObjectMeta(
-                "S",
-                name="ErrorDetails_ScriptStackTrace",
-                optional=True
-            )),
-            ('extended_info_present', ObjectMeta(
-                "B", name="SerializeExtendedInfo"
-            )),
-            ('invocation_name', ObjectMeta(
-                "S",
-                optional=True,
-                name="InvocationInfo_InvocationName"
-            )),
-            ('invocation_bound_parameters', DictionaryMeta(
-                name="InvocationInfo_BoundParameters",
-                optional=True,
-                dict_key_meta=ObjectMeta("S"),
-                dict_types=[
-                    "System.Management.Automation.PSBoundParametersDictionary",
-                    "System.Collections.Generic.Dictionary`2[[System.String, "
-                    "mscorlib, Version=4.0.0.0, Culture=neutral, "
-                    "PublicKeyToken=b77a5c561934e089],"
-                    "[System.Object, mscorlib, Version=4.0.0.0, "
-                    "Culture=neutral, PublicKeyToken=b77a5c561934e089]]",
-                    "System.Object"
-                ]
-            )),
-            ('invocation_unbound_arguments', ListMeta(
-                name="InvocationInfo_UnboundArguments",
-                optional=True,
-                list_types=[
-                    "System.Collections.Generic.List`1[["
-                    "System.Object, mscorlib, Version=4.0.0.0, "
-                    "Culture=neutral, PublicKeyToken=b77a5c561934e089]]",
-                    "System.Object"
-                ]
-            )),
-            ('invocation_command_origin', ObjectMeta(
-                "Obj",
-                name="InvocationInfo_CommandOrigin",
-                optional=True,
-                object=CommandOrigin
-            )),
-            ('invocation_expecting_input', ObjectMeta(
-                "B",
-                name="InvocationInfo_ExpectingInput",
-                optional=True
-            )),
-            ('invocation_line', ObjectMeta(
-                "S",
-                name="InvocationInfo_Line",
-                optional=True
-            )),
-            ('invocation_offset_in_line', ObjectMeta(
-                "I32",
-                name="InvocationInfo_OffsetInLine",
-                optional=True
-            )),
-            ('invocation_position_message', ObjectMeta(
-                "S",
-                name="InvocationInfo_PositionMessage",
-                optional=True
-            )),
-            ('invocation_script_name', ObjectMeta(
-                "S",
-                name="InvocationInfo_ScriptName",
-                optional=True
-            )),
-            ('invocation_script_line_number', ObjectMeta(
-                "I32",
-                name="InvocationInfo_ScriptLineNumber",
-                optional=True
-            )),
-            ('invocation_history_id', ObjectMeta(
-                "I64",
-                name="InvocationInfo_HistoryId",
-                optional=True
-            )),
-            ('invocation_pipeline_length', ObjectMeta(
-                "I32",
-                name="InvocationInfo_PipelineLength",
-                optional=True
-            )),
-            ('invocation_pipeline_position', ObjectMeta(
-                "I32",
-                name="InvocationInfo_PipelinePosition",
-                optional=True
-            )),
-            ('invocation_pipeline_iteration_info', ListMeta(
-                name="InvocationInfo_PipelineIterationInfo",
-                optional=True,
-                list_value_meta=ObjectMeta("I32"),
-                list_types=["System.In32[]", "System.Array", "System.Object"]
-            )),
-            ('command_type', ObjectMeta(
-                "Obj",
-                name="CommandInfo_CommandType",
-                object=CommandType,
-                optional=True,
-            )),
-            ('command_definition', ObjectMeta(
-                "S",
-                name="CommandInfo_Definition",
-                optional=True,
-            )),
-            ('command_name', ObjectMeta(
-                "S",
-                name="CommandInfo_Name",
-                optional=True
-            )),
-            ('command_visibility', ObjectMeta(
-                "Obj",
-                name="CommandInfo_Visibility",
-                object=SessionStateEntryVisibility,
-                optional=True
-            )),
-            ('pipeline_iteration_info', ListMeta(
-                name="PipelineIterationInfo", optional=True,
-                list_value_meta=ObjectMeta("I32"),
-                list_types=[
-                    "System.Collections.ObjectModel.ReadOnlyCollection`1[["
-                    "System.Int32, mscorlib, Version=4.0.0.0, "
-                    "Culture=neutral, PublicKeyToken=b77a5c561934e089]]",
-                    "System.Object"
-                ]
-            )),
+            ("exception", ObjectMeta(name="Exception", optional=True)),
+            ("target_object", ObjectMeta(name="TargetObject", optional=True)),
+            ("invocation", ObjectMeta("B", name="SerializeExtendedInfo")),
+            (
+                "invocation_info",
+                ObjectMeta("ObjDynamic", name="InvocationInfo", object=GenericComplexObject, optional=True),
+            ),
+            ("fq_error", ObjectMeta("S", name="FullyQualifiedErrorId")),
+            ("category", ObjectMeta("I32", name="ErrorCategory_Category")),
+            ("activity", ObjectMeta("S", name="ErrorCategory_Activity", optional=True)),
+            ("reason", ObjectMeta("S", name="ErrorCategory_Reason", optional=True)),
+            ("target_name", ObjectMeta("S", name="ErrorCategory_TargetName", optional=True)),
+            ("target_type", ObjectMeta("S", name="ErrorCategory_TargetType", optional=True)),
+            ("message", ObjectMeta("S", name="ErrorCategory_Message", optional=True)),
+            ("details_message", ObjectMeta("S", name="ErrorDetails_Message", optional=True)),
+            ("action", ObjectMeta("S", name="ErrorDetails_RecommendedAction", optional=True)),
+            ("script_stacktrace", ObjectMeta("S", name="ErrorDetails_ScriptStackTrace", optional=True)),
+            ("extended_info_present", ObjectMeta("B", name="SerializeExtendedInfo")),
+            ("invocation_name", ObjectMeta("S", optional=True, name="InvocationInfo_InvocationName")),
+            (
+                "invocation_bound_parameters",
+                DictionaryMeta(
+                    name="InvocationInfo_BoundParameters",
+                    optional=True,
+                    dict_key_meta=ObjectMeta("S"),
+                    dict_types=[
+                        "System.Management.Automation.PSBoundParametersDictionary",
+                        "System.Collections.Generic.Dictionary`2[[System.String, "
+                        "mscorlib, Version=4.0.0.0, Culture=neutral, "
+                        "PublicKeyToken=b77a5c561934e089],"
+                        "[System.Object, mscorlib, Version=4.0.0.0, "
+                        "Culture=neutral, PublicKeyToken=b77a5c561934e089]]",
+                        "System.Object",
+                    ],
+                ),
+            ),
+            (
+                "invocation_unbound_arguments",
+                ListMeta(
+                    name="InvocationInfo_UnboundArguments",
+                    optional=True,
+                    list_types=[
+                        "System.Collections.Generic.List`1[["
+                        "System.Object, mscorlib, Version=4.0.0.0, "
+                        "Culture=neutral, PublicKeyToken=b77a5c561934e089]]",
+                        "System.Object",
+                    ],
+                ),
+            ),
+            (
+                "invocation_command_origin",
+                ObjectMeta("Obj", name="InvocationInfo_CommandOrigin", optional=True, object=CommandOrigin),
+            ),
+            ("invocation_expecting_input", ObjectMeta("B", name="InvocationInfo_ExpectingInput", optional=True)),
+            ("invocation_line", ObjectMeta("S", name="InvocationInfo_Line", optional=True)),
+            ("invocation_offset_in_line", ObjectMeta("I32", name="InvocationInfo_OffsetInLine", optional=True)),
+            ("invocation_position_message", ObjectMeta("S", name="InvocationInfo_PositionMessage", optional=True)),
+            ("invocation_script_name", ObjectMeta("S", name="InvocationInfo_ScriptName", optional=True)),
+            ("invocation_script_line_number", ObjectMeta("I32", name="InvocationInfo_ScriptLineNumber", optional=True)),
+            ("invocation_history_id", ObjectMeta("I64", name="InvocationInfo_HistoryId", optional=True)),
+            ("invocation_pipeline_length", ObjectMeta("I32", name="InvocationInfo_PipelineLength", optional=True)),
+            ("invocation_pipeline_position", ObjectMeta("I32", name="InvocationInfo_PipelinePosition", optional=True)),
+            (
+                "invocation_pipeline_iteration_info",
+                ListMeta(
+                    name="InvocationInfo_PipelineIterationInfo",
+                    optional=True,
+                    list_value_meta=ObjectMeta("I32"),
+                    list_types=["System.In32[]", "System.Array", "System.Object"],
+                ),
+            ),
+            (
+                "command_type",
+                ObjectMeta(
+                    "Obj",
+                    name="CommandInfo_CommandType",
+                    object=CommandType,
+                    optional=True,
+                ),
+            ),
+            (
+                "command_definition",
+                ObjectMeta(
+                    "S",
+                    name="CommandInfo_Definition",
+                    optional=True,
+                ),
+            ),
+            ("command_name", ObjectMeta("S", name="CommandInfo_Name", optional=True)),
+            (
+                "command_visibility",
+                ObjectMeta("Obj", name="CommandInfo_Visibility", object=SessionStateEntryVisibility, optional=True),
+            ),
+            (
+                "pipeline_iteration_info",
+                ListMeta(
+                    name="PipelineIterationInfo",
+                    optional=True,
+                    list_value_meta=ObjectMeta("I32"),
+                    list_types=[
+                        "System.Collections.ObjectModel.ReadOnlyCollection`1[["
+                        "System.Int32, mscorlib, Version=4.0.0.0, "
+                        "Culture=neutral, PublicKeyToken=b77a5c561934e089]]",
+                        "System.Object",
+                    ],
+                ),
+            ),
         )
-        self.exception = kwargs.get('exception')
-        self.target_info = kwargs.get('target_info')
-        self.invocation = kwargs.get('invocation')
-        self.fq_error = kwargs.get('fq_error')
-        self.category = kwargs.get('category')
-        self.activity = kwargs.get('activity')
-        self.reason = kwargs.get('reason')
-        self.target_name = kwargs.get('target_name')
-        self.target_type = kwargs.get('target_type')
-        self.message = kwargs.get('message')
-        self.details_message = kwargs.get('details_message')
-        self.action = kwargs.get('action')
-        self.pipeline_iteration_info = kwargs.get('pipeline_iteration_info')
-        self.invocation_name = kwargs.get('invocation_name')
-        self.invocation_bound_parameters = \
-            kwargs.get('invocation_bound_parameters')
-        self.invocation_unbound_arguments = \
-            kwargs.get('invocation_unbound_arguments')
-        self.invocation_command_origin = \
-            kwargs.get('invocation_command_origin')
-        self.invocation_expecting_input = \
-            kwargs.get('invocation_expecting_input')
-        self.invocation_line = kwargs.get('invocation_line')
-        self.invocation_offset_in_line = \
-            kwargs.get('invocation_offset_in_line')
-        self.invocation_position_message = \
-            kwargs.get('invocation_position_message')
-        self.invocation_script_name = kwargs.get('invocation_script_name')
-        self.invocation_script_line_number = \
-            kwargs.get('invocation_script_line_number')
-        self.invocation_history_id = kwargs.get('invocation_history_id')
-        self.invocation_pipeline_length = \
-            kwargs.get('invocation_pipeline_length')
-        self.invocation_pipeline_position = \
-            kwargs.get('invocation_pipeline_position')
-        self.invocation_pipeline_iteration_info = \
-            kwargs.get('invocation_pipeline_iteration_info')
-        self.command_type = kwargs.get('command_type')
-        self.command_definition = kwargs.get('command_definition')
-        self.command_name = kwargs.get('command_name')
-        self.command_visibility = kwargs.get('command_visibility')
+        self.exception = kwargs.get("exception")
+        self.target_info = kwargs.get("target_info")
+        self.invocation = kwargs.get("invocation")
+        self.fq_error = kwargs.get("fq_error")
+        self.category = kwargs.get("category")
+        self.activity = kwargs.get("activity")
+        self.reason = kwargs.get("reason")
+        self.target_name = kwargs.get("target_name")
+        self.target_type = kwargs.get("target_type")
+        self.message = kwargs.get("message")
+        self.details_message = kwargs.get("details_message")
+        self.action = kwargs.get("action")
+        self.pipeline_iteration_info = kwargs.get("pipeline_iteration_info")
+        self.invocation_name = kwargs.get("invocation_name")
+        self.invocation_bound_parameters = kwargs.get("invocation_bound_parameters")
+        self.invocation_unbound_arguments = kwargs.get("invocation_unbound_arguments")
+        self.invocation_command_origin = kwargs.get("invocation_command_origin")
+        self.invocation_expecting_input = kwargs.get("invocation_expecting_input")
+        self.invocation_line = kwargs.get("invocation_line")
+        self.invocation_offset_in_line = kwargs.get("invocation_offset_in_line")
+        self.invocation_position_message = kwargs.get("invocation_position_message")
+        self.invocation_script_name = kwargs.get("invocation_script_name")
+        self.invocation_script_line_number = kwargs.get("invocation_script_line_number")
+        self.invocation_history_id = kwargs.get("invocation_history_id")
+        self.invocation_pipeline_length = kwargs.get("invocation_pipeline_length")
+        self.invocation_pipeline_position = kwargs.get("invocation_pipeline_position")
+        self.invocation_pipeline_iteration_info = kwargs.get("invocation_pipeline_iteration_info")
+        self.command_type = kwargs.get("command_type")
+        self.command_definition = kwargs.get("command_definition")
+        self.command_name = kwargs.get("command_name")
+        self.command_visibility = kwargs.get("command_visibility")
         self.extended_info_present = self.invocation is not None
 
 
 class InformationalRecord(ComplexObject):
-
     def __init__(self, **kwargs):
         """
         [MS-PSRP] 2.2.3.16 InformationalRecord (Debug/Warning/Verbose)
         https://msdn.microsoft.com/en-us/library/dd305072.aspx
         """
         super(InformationalRecord, self).__init__()
-        self._types = [
-            "System.Management.Automation.InformationRecord",
-            "System.Object"
-        ]
+        self._types = ["System.Management.Automation.InformationRecord", "System.Object"]
         self._extended_properties = (
-            ('message', ObjectMeta("S", name="InformationalRecord_Message")),
-            ('invocation', ObjectMeta(
-                "B", name="InformationalRecord_SerializeInvocationInfo"
-            )),
-            ('invocation_name', ObjectMeta(
-                "S",
-                optional=True,
-                name="InvocationInfo_InvocationName"
-            )),
-            ('invocation_bound_parameters', DictionaryMeta(
-                name="InvocationInfo_BoundParameters",
-                optional=True,
-                dict_key_meta=ObjectMeta("S"),
-                dict_types=[
-                    "System.Management.Automation.PSBoundParametersDictionary",
-                    "System.Collections.Generic.Dictionary`2[[System.String, "
-                    "mscorlib, Version=4.0.0.0, Culture=neutral, "
-                    "PublicKeyToken=b77a5c561934e089],"
-                    "[System.Object, mscorlib, Version=4.0.0.0, "
-                    "Culture=neutral, PublicKeyToken=b77a5c561934e089]]",
-                    "System.Object"
-                ]
-            )),
-            ('invocation_unbound_arguments', ListMeta(
-                name="InvocationInfo_UnboundArguments",
-                optional=True,
-                list_types=[
-                    "System.Collections.Generic.List`1[["
-                    "System.Object, mscorlib, Version=4.0.0.0, "
-                    "Culture=neutral, PublicKeyToken=b77a5c561934e089]]",
-                    "System.Object"
-                ]
-            )),
-            ('invocation_command_origin', ObjectMeta(
-                "Obj",
-                name="InvocationInfo_CommandOrigin",
-                optional=True,
-                object=CommandOrigin
-            )),
-            ('invocation_expecting_input', ObjectMeta(
-                "B",
-                name="InvocationInfo_ExpectingInput",
-                optional=True
-            )),
-            ('invocation_line', ObjectMeta(
-                "S",
-                name="InvocationInfo_Line",
-                optional=True
-            )),
-            ('invocation_offset_in_line', ObjectMeta(
-                "I32",
-                name="InvocationInfo_OffsetInLine",
-                optional=True
-            )),
-            ('invocation_position_message', ObjectMeta(
-                "S",
-                name="InvocationInfo_PositionMessage",
-                optional=True
-            )),
-            ('invocation_script_name', ObjectMeta(
-                "S",
-                name="InvocationInfo_ScriptName",
-                optional=True
-            )),
-            ('invocation_script_line_number', ObjectMeta(
-                "I32",
-                name="InvocationInfo_ScriptLineNumber",
-                optional=True
-            )),
-            ('invocation_history_id', ObjectMeta(
-                "I64",
-                name="InvocationInfo_HistoryId",
-                optional=True
-            )),
-            ('invocation_pipeline_length', ObjectMeta(
-                "I32",
-                name="InvocationInfo_PipelineLength",
-                optional=True
-            )),
-            ('invocation_pipeline_position', ObjectMeta(
-                "I32",
-                name="InvocationInfo_PipelinePosition",
-                optional=True
-            )),
-            ('invocation_pipeline_iteration_info', ListMeta(
-                name="InvocationInfo_PipelineIterationInfo",
-                optional=True,
-                list_value_meta=ObjectMeta("I32"),
-                list_types=["System.In32[]", "System.Array", "System.Object"]
-            )),
-            ('command_type', ObjectMeta(
-                "Obj",
-                name="CommandInfo_CommandType",
-                object=CommandType,
-                optional=True,
-            )),
-            ('command_definition', ObjectMeta(
-                "S",
-                name="CommandInfo_Definition",
-                optional=True,
-            )),
-            ('command_name', ObjectMeta(
-                "S",
-                name="CommandInfo_Name",
-                optional=True
-            )),
-            ('command_visibility', ObjectMeta(
-                "Obj",
-                name="CommandInfo_Visibility",
-                object=SessionStateEntryVisibility,
-                optional=True
-            )),
-            ('pipeline_iteration_info', ListMeta(
-                name="InformationalRecord_PipelineIterationInfo",
-                optional=True,
-                list_value_meta=ObjectMeta("I32"),
-                list_types=[
-                    "System.Collections.ObjectModel.ReadOnlyCollection`1[["
-                    "System.Int32, mscorlib, Version=4.0.0.0, "
-                    "Culture=neutral, PublicKeyToken=b77a5c561934e089]]",
-                    "System.Object"
-                ]
-            ))
+            ("message", ObjectMeta("S", name="InformationalRecord_Message")),
+            ("invocation", ObjectMeta("B", name="InformationalRecord_SerializeInvocationInfo")),
+            ("invocation_name", ObjectMeta("S", optional=True, name="InvocationInfo_InvocationName")),
+            (
+                "invocation_bound_parameters",
+                DictionaryMeta(
+                    name="InvocationInfo_BoundParameters",
+                    optional=True,
+                    dict_key_meta=ObjectMeta("S"),
+                    dict_types=[
+                        "System.Management.Automation.PSBoundParametersDictionary",
+                        "System.Collections.Generic.Dictionary`2[[System.String, "
+                        "mscorlib, Version=4.0.0.0, Culture=neutral, "
+                        "PublicKeyToken=b77a5c561934e089],"
+                        "[System.Object, mscorlib, Version=4.0.0.0, "
+                        "Culture=neutral, PublicKeyToken=b77a5c561934e089]]",
+                        "System.Object",
+                    ],
+                ),
+            ),
+            (
+                "invocation_unbound_arguments",
+                ListMeta(
+                    name="InvocationInfo_UnboundArguments",
+                    optional=True,
+                    list_types=[
+                        "System.Collections.Generic.List`1[["
+                        "System.Object, mscorlib, Version=4.0.0.0, "
+                        "Culture=neutral, PublicKeyToken=b77a5c561934e089]]",
+                        "System.Object",
+                    ],
+                ),
+            ),
+            (
+                "invocation_command_origin",
+                ObjectMeta("Obj", name="InvocationInfo_CommandOrigin", optional=True, object=CommandOrigin),
+            ),
+            ("invocation_expecting_input", ObjectMeta("B", name="InvocationInfo_ExpectingInput", optional=True)),
+            ("invocation_line", ObjectMeta("S", name="InvocationInfo_Line", optional=True)),
+            ("invocation_offset_in_line", ObjectMeta("I32", name="InvocationInfo_OffsetInLine", optional=True)),
+            ("invocation_position_message", ObjectMeta("S", name="InvocationInfo_PositionMessage", optional=True)),
+            ("invocation_script_name", ObjectMeta("S", name="InvocationInfo_ScriptName", optional=True)),
+            ("invocation_script_line_number", ObjectMeta("I32", name="InvocationInfo_ScriptLineNumber", optional=True)),
+            ("invocation_history_id", ObjectMeta("I64", name="InvocationInfo_HistoryId", optional=True)),
+            ("invocation_pipeline_length", ObjectMeta("I32", name="InvocationInfo_PipelineLength", optional=True)),
+            ("invocation_pipeline_position", ObjectMeta("I32", name="InvocationInfo_PipelinePosition", optional=True)),
+            (
+                "invocation_pipeline_iteration_info",
+                ListMeta(
+                    name="InvocationInfo_PipelineIterationInfo",
+                    optional=True,
+                    list_value_meta=ObjectMeta("I32"),
+                    list_types=["System.In32[]", "System.Array", "System.Object"],
+                ),
+            ),
+            (
+                "command_type",
+                ObjectMeta(
+                    "Obj",
+                    name="CommandInfo_CommandType",
+                    object=CommandType,
+                    optional=True,
+                ),
+            ),
+            (
+                "command_definition",
+                ObjectMeta(
+                    "S",
+                    name="CommandInfo_Definition",
+                    optional=True,
+                ),
+            ),
+            ("command_name", ObjectMeta("S", name="CommandInfo_Name", optional=True)),
+            (
+                "command_visibility",
+                ObjectMeta("Obj", name="CommandInfo_Visibility", object=SessionStateEntryVisibility, optional=True),
+            ),
+            (
+                "pipeline_iteration_info",
+                ListMeta(
+                    name="InformationalRecord_PipelineIterationInfo",
+                    optional=True,
+                    list_value_meta=ObjectMeta("I32"),
+                    list_types=[
+                        "System.Collections.ObjectModel.ReadOnlyCollection`1[["
+                        "System.Int32, mscorlib, Version=4.0.0.0, "
+                        "Culture=neutral, PublicKeyToken=b77a5c561934e089]]",
+                        "System.Object",
+                    ],
+                ),
+            ),
         )
-        self.message = kwargs.get('message')
-        self.pipeline_iteration_info = kwargs.get('pipeline_iteration_info')
-        self.invocation_name = kwargs.get('invocation_name')
-        self.invocation_bound_parameters = \
-            kwargs.get('invocation_bound_parameters')
-        self.invocation_unbound_arguments = \
-            kwargs.get('invocation_unbound_arguments')
-        self.invocation_command_origin = \
-            kwargs.get('invocation_command_origin')
-        self.invocation_expecting_input = \
-            kwargs.get('invocation_expecting_input')
-        self.invocation_line = kwargs.get('invocation_line')
-        self.invocation_offset_in_line = \
-            kwargs.get('invocation_offset_in_line')
-        self.invocation_position_message = \
-            kwargs.get('invocation_position_message')
-        self.invocation_script_name = kwargs.get('invocation_script_name')
-        self.invocation_script_line_number = \
-            kwargs.get('invocation_script_line_number')
-        self.invocation_history_id = kwargs.get('invocation_history_id')
-        self.invocation_pipeline_length = \
-            kwargs.get('invocation_pipeline_length')
-        self.invocation_pipeline_position = \
-            kwargs.get('invocation_pipeline_position')
-        self.invocation_pipeline_iteration_info = \
-            kwargs.get('invocation_pipeline_iteration_info')
-        self.command_type = kwargs.get('command_type')
-        self.command_definition = kwargs.get('command_definition')
-        self.command_name = kwargs.get('command_name')
-        self.command_visibility = kwargs.get('command_visibility')
+        self.message = kwargs.get("message")
+        self.pipeline_iteration_info = kwargs.get("pipeline_iteration_info")
+        self.invocation_name = kwargs.get("invocation_name")
+        self.invocation_bound_parameters = kwargs.get("invocation_bound_parameters")
+        self.invocation_unbound_arguments = kwargs.get("invocation_unbound_arguments")
+        self.invocation_command_origin = kwargs.get("invocation_command_origin")
+        self.invocation_expecting_input = kwargs.get("invocation_expecting_input")
+        self.invocation_line = kwargs.get("invocation_line")
+        self.invocation_offset_in_line = kwargs.get("invocation_offset_in_line")
+        self.invocation_position_message = kwargs.get("invocation_position_message")
+        self.invocation_script_name = kwargs.get("invocation_script_name")
+        self.invocation_script_line_number = kwargs.get("invocation_script_line_number")
+        self.invocation_history_id = kwargs.get("invocation_history_id")
+        self.invocation_pipeline_length = kwargs.get("invocation_pipeline_length")
+        self.invocation_pipeline_position = kwargs.get("invocation_pipeline_position")
+        self.invocation_pipeline_iteration_info = kwargs.get("invocation_pipeline_iteration_info")
+        self.command_type = kwargs.get("command_type")
+        self.command_definition = kwargs.get("command_definition")
+        self.command_name = kwargs.get("command_name")
+        self.command_visibility = kwargs.get("command_visibility")
         self.invocation = False
 
 
 class HostMethodIdentifier(Enum):
-
     def __init__(self, **kwargs):
         """
         [MS-PSRP] 2.2.3.17 Host Method Identifier
@@ -1231,11 +1120,10 @@ class HostMethodIdentifier(Enum):
             53: "PopRunspace",
             54: "GetIsRunspacePushed",
             55: "GetRunspce",
-            56: "PromptForChoiceMultipleSelection"
+            56: "PromptForChoiceMultipleSelection",
         }
         super(HostMethodIdentifier, self).__init__(
-            "System.Management.Automation.Remoting.RemoteHostMethodId",
-            string_map, **kwargs
+            "System.Management.Automation.Remoting.RemoteHostMethodId", string_map, **kwargs
         )
 
 
@@ -1258,12 +1146,10 @@ class CommandType(Enum):
 
         :param value: The initial flag value for CommandType
         """
-        super(CommandType, self).__init__(
-            "System.Management.Automation.CommandTypes", {}, **kwargs
-        )
+        super(CommandType, self).__init__("System.Management.Automation.CommandTypes", {}, **kwargs)
 
-    @property
-    def _to_string(self):
+    @property  # type: ignore[override]
+    def _to_string(self) -> str:  # type: ignore[override]
         if self.value == 0x01FF:
             return "All"
 
@@ -1280,7 +1166,7 @@ class CommandType(Enum):
         )
         values = []
         for name, flag in string_map:
-            if self.value & flag == flag:
+            if (self.value or 0) & flag == flag:
                 values.append(name)
         return ", ".join(values)
 
@@ -1290,7 +1176,6 @@ class CommandType(Enum):
 
 
 class CommandMetadataCount(ComplexObject):
-
     def __init__(self, **kwargs):
         """
         [MS-PSRP] 2.2.3.21 CommandMetadataCount
@@ -1303,16 +1188,13 @@ class CommandMetadataCount(ComplexObject):
         self.types = [
             "Selected.Microsoft.PowerShell.Commands.GenericMeasureInfo",
             "System.Management.Automation.PSCustomObject",
-            "System.Object"
+            "System.Object",
         ]
-        self._extended_properties = (
-            ('count', ObjectMeta("I32", name="Count")),
-        )
-        self.count = kwargs.get('count')
+        self._extended_properties = (("count", ObjectMeta("I32", name="Count")),)
+        self.count = kwargs.get("count")
 
 
 class CommandMetadata(ComplexObject):
-
     def __init__(self, **kwargs):
         """
         [MS-PSRP] 2.2.3.22 CommandMetadata
@@ -1328,42 +1210,43 @@ class CommandMetadata(ComplexObject):
             as Command Parameters
         """
         super(CommandMetadata, self).__init__()
-        self.types = [
-            "System.Management.Automation.PSCustomObject",
-            "System.Object"
-        ]
+        self.types = ["System.Management.Automation.PSCustomObject", "System.Object"]
         self._extended_properties = (
-            ('name', ObjectMeta("S", name="Name")),
-            ('namespace', ObjectMeta("S", name="Namespace")),
-            ('help_uri', ObjectMeta("S", name="HelpUri")),
-            ('command_type', ObjectMeta("Obj", name="CommandType",
-                                        object=CommandType)),
-            ('output_type', ListMeta(
-                name="OutputType",
-                list_value_meta=ObjectMeta("S"),
-                list_types=[
-                    "System.Collections.ObjectModel.ReadOnlyCollection`1[["
-                    "System.Management.Automation.PSTypeName, "
-                    "System.Management.Automation, Version=3.0.0.0, "
-                    "Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
-                ]
-            )),
-            ('parameters', DictionaryMeta(
-                name="Parameters",
-                dict_key_meta=ObjectMeta("S"),
-                dict_value_meta=ObjectMeta("Obj", object=ParameterMetadata))
-             ),
+            ("name", ObjectMeta("S", name="Name")),
+            ("namespace", ObjectMeta("S", name="Namespace")),
+            ("help_uri", ObjectMeta("S", name="HelpUri")),
+            ("command_type", ObjectMeta("Obj", name="CommandType", object=CommandType)),
+            (
+                "output_type",
+                ListMeta(
+                    name="OutputType",
+                    list_value_meta=ObjectMeta("S"),
+                    list_types=[
+                        "System.Collections.ObjectModel.ReadOnlyCollection`1[["
+                        "System.Management.Automation.PSTypeName, "
+                        "System.Management.Automation, Version=3.0.0.0, "
+                        "Culture=neutral, PublicKeyToken=31bf3856ad364e35]]",
+                    ],
+                ),
+            ),
+            (
+                "parameters",
+                DictionaryMeta(
+                    name="Parameters",
+                    dict_key_meta=ObjectMeta("S"),
+                    dict_value_meta=ObjectMeta("Obj", object=ParameterMetadata),
+                ),
+            ),
         )
-        self.name = kwargs.get('name')
-        self.namespace = kwargs.get('namespace')
-        self.help_uri = kwargs.get('help_uri')
-        self.command_type = kwargs.get('command_type')
-        self.output_type = kwargs.get('output_type')
-        self.parameters = kwargs.get('parameters')
+        self.name = kwargs.get("name")
+        self.namespace = kwargs.get("namespace")
+        self.help_uri = kwargs.get("help_uri")
+        self.command_type = kwargs.get("command_type")
+        self.output_type = kwargs.get("output_type")
+        self.parameters = kwargs.get("parameters")
 
 
 class ParameterMetadata(ComplexObject):
-
     def __init__(self, **kwargs):
         """
         [MS-PSRP] 2.2.3.23 ParameterMetadata
@@ -1377,35 +1260,34 @@ class ParameterMetadata(ComplexObject):
             specified in the ArgumentList property
         """
         super(ParameterMetadata, self).__init__()
-        self.types = [
-            "System.Management.Automation.ParameterMetadata",
-            "System.Object"
-        ]
+        self.types = ["System.Management.Automation.ParameterMetadata", "System.Object"]
         self._adapted_properties = (
-            ('name', ObjectMeta("S", name="Name")),
-            ('parameter_type', ObjectMeta("S", name="ParameterType")),
-            ('aliases', ListMeta(
-                name="Aliases",
-                list_value_meta=ObjectMeta("S"),
-                list_types=[
-                    "System.Collections.ObjectModel.Collection`1"
-                    "[[System.String, mscorlib, Version=4.0.0.0, "
-                    "Culture=neutral, PublicKeyToken=b77a5c561934e089]]",
-                    "System.Object"
-                ])
-             ),
-            ('switch_parameter', ObjectMeta("B", name="SwitchParameter")),
-            ('dynamic', ObjectMeta("B", name="IsDynamic")),
+            ("name", ObjectMeta("S", name="Name")),
+            ("parameter_type", ObjectMeta("S", name="ParameterType")),
+            (
+                "aliases",
+                ListMeta(
+                    name="Aliases",
+                    list_value_meta=ObjectMeta("S"),
+                    list_types=[
+                        "System.Collections.ObjectModel.Collection`1"
+                        "[[System.String, mscorlib, Version=4.0.0.0, "
+                        "Culture=neutral, PublicKeyToken=b77a5c561934e089]]",
+                        "System.Object",
+                    ],
+                ),
+            ),
+            ("switch_parameter", ObjectMeta("B", name="SwitchParameter")),
+            ("dynamic", ObjectMeta("B", name="IsDynamic")),
         )
-        self.name = kwargs.get('name')
-        self.parameter_type = kwargs.get('parameter_type')
-        self.aliases = kwargs.get('aliases')
-        self.switch_parameter = kwargs.get('switch_parameter')
-        self.dynamic = kwargs.get('dynamic')
+        self.name = kwargs.get("name")
+        self.parameter_type = kwargs.get("parameter_type")
+        self.aliases = kwargs.get("aliases")
+        self.switch_parameter = kwargs.get("switch_parameter")
+        self.dynamic = kwargs.get("dynamic")
 
 
 class PSCredential(ComplexObject):
-
     def __init__(self, **kwargs):
         """
         [MS-PSRP] 2.2.3.25 PSCredential
@@ -1420,22 +1302,18 @@ class PSCredential(ComplexObject):
             string in order to make sure the encoding is correct
         """
         super(PSCredential, self).__init__()
-        self._types = [
-            "System.Management.Automation.PSCredential",
-            "System.Object"
-        ]
+        self._types = ["System.Management.Automation.PSCredential", "System.Object"]
         self._adapted_properties = (
-            ('username', ObjectMeta("S", name="UserName")),
-            ('password', ObjectMeta("SS", name="Password")),
+            ("username", ObjectMeta("S", name="UserName")),
+            ("password", ObjectMeta("SS", name="Password")),
         )
         self._to_string = "System.Management.Automation.PSCredential"
 
-        self.username = kwargs.get('username')
-        self.password = kwargs.get('password')
+        self.username = kwargs.get("username")
+        self.password = kwargs.get("password")
 
 
 class KeyInfo(ComplexObject):
-
     def __init__(self, **kwargs):
         """
         [MS-PSRP] 2.2.3.26 KeyInfo
@@ -1452,19 +1330,18 @@ class KeyInfo(ComplexObject):
         """
         super(KeyInfo, self).__init__()
         self._extended_properties = (
-            ('code', ObjectMeta("I32", name="virtualKeyCode", optional=True)),
-            ('character', ObjectMeta("C", name="character")),
-            ('state', ObjectMeta("I32", name="controlKeyState")),
-            ('key_down', ObjectMeta("B", name="keyDown")),
+            ("code", ObjectMeta("I32", name="virtualKeyCode", optional=True)),
+            ("character", ObjectMeta("C", name="character")),
+            ("state", ObjectMeta("I32", name="controlKeyState")),
+            ("key_down", ObjectMeta("B", name="keyDown")),
         )
-        self.code = kwargs.get('code')
-        self.character = kwargs.get('character')
-        self.state = kwargs.get('state')
-        self.key_down = kwargs.get('key_down')
+        self.code = kwargs.get("code")
+        self.character = kwargs.get("character")
+        self.state = kwargs.get("state")
+        self.key_down = kwargs.get("key_down")
 
 
 class KeyInfoDotNet(ComplexObject):
-
     def __init__(self, **kwargs):
         """
         System.Management.Automation.Host.KeyInfo
@@ -1479,21 +1356,17 @@ class KeyInfoDotNet(ComplexObject):
         :param key_down: Whether the key is pressed or released
         """
         super(KeyInfoDotNet, self).__init__()
-        self._types = [
-            "System.Management.Automation.Host.KeyInfo",
-            "System.ValueType",
-            "System.Object"
-        ]
+        self._types = ["System.Management.Automation.Host.KeyInfo", "System.ValueType", "System.Object"]
         self._adapted_properties = (
-            ('code', ObjectMeta("I32", name="VirtualKeyCode")),
-            ('character', ObjectMeta("C", name="Character")),
-            ('state', ObjectMeta("S", name="ControlKeyState")),
-            ('key_down', ObjectMeta("B", name="KeyDown")),
+            ("code", ObjectMeta("I32", name="VirtualKeyCode")),
+            ("character", ObjectMeta("C", name="Character")),
+            ("state", ObjectMeta("S", name="ControlKeyState")),
+            ("key_down", ObjectMeta("B", name="KeyDown")),
         )
-        self.code = kwargs.get('code')
-        self.character = kwargs.get('character')
-        self.state = kwargs.get('state')
-        self.key_down = kwargs.get('key_down')
+        self.code = kwargs.get("code")
+        self.character = kwargs.get("character")
+        self.state = kwargs.get("state")
+        self.key_down = kwargs.get("key_down")
 
 
 class ControlKeyState(object):
@@ -1504,6 +1377,7 @@ class ControlKeyState(object):
 
     A set of zero or more control keys that are help down.
     """
+
     RightAltPressed = 0x0001
     LeftAltPressed = 0x0002
     RightCtrlPressed = 0x0004
@@ -1516,7 +1390,6 @@ class ControlKeyState(object):
 
 
 class BufferCell(ComplexObject):
-
     def __init__(self, **kwargs):
         """
         [MS-PSRP] 2.2.3.28 BufferCell
@@ -1531,17 +1404,15 @@ class BufferCell(ComplexObject):
         """
         super(BufferCell, self).__init__()
         self._adapted_properties = (
-            ('character', ObjectMeta("C", name="character")),
-            ('foreground_color', ObjectMeta("Obj", name="foregroundColor",
-                                            object=Color)),
-            ('background_color', ObjectMeta("Obj", name="backgroundColor",
-                                            object=Color)),
-            ('cell_type', ObjectMeta("I32", name="bufferCellType")),
+            ("character", ObjectMeta("C", name="character")),
+            ("foreground_color", ObjectMeta("Obj", name="foregroundColor", object=Color)),
+            ("background_color", ObjectMeta("Obj", name="backgroundColor", object=Color)),
+            ("cell_type", ObjectMeta("I32", name="bufferCellType")),
         )
-        self.character = kwargs.get('character')
-        self.foreground_color = kwargs.get('foreground_color')
-        self.background_color = kwargs.get('background_color')
-        self.cell_type = kwargs.get('cell_type')
+        self.character = kwargs.get("character")
+        self.foreground_color = kwargs.get("foreground_color")
+        self.background_color = kwargs.get("background_color")
+        self.cell_type = kwargs.get("cell_type")
 
 
 class BufferCellType(object):
@@ -1551,13 +1422,13 @@ class BufferCellType(object):
 
     The type of a cell of a screen buffer.
     """
+
     COMPLETE = 0
     LEADING = 1
     TRAILING = 2
 
 
 class Array(ComplexObject):
-
     def __init__(self, **kwargs):
         """
         [MS-PSRP] 2.2.6.1.4 Array
@@ -1570,13 +1441,13 @@ class Array(ComplexObject):
         """
         super(Array, self).__init__()
         self._extended_properties = (
-            ('mae', ListMeta(name="mae")),
-            ('mal', ListMeta(name="mal", list_value_meta=ObjectMeta("I32"))),
+            ("mae", ListMeta(name="mae")),
+            ("mal", ListMeta(name="mal", list_value_meta=ObjectMeta("I32"))),
         )
         self._array = None
         self._mae = None
         self._mal = None
-        self._array = kwargs.get('array')
+        self._array = kwargs.get("array")
 
     @property
     def array(self):
@@ -1664,13 +1535,10 @@ class CommandOrigin(Enum):
         :param value: The command origin flag to set
         """
         string_map = {
-            0: 'Runspace',
-            1: 'Internal',
+            0: "Runspace",
+            1: "Internal",
         }
-        super(CommandOrigin, self).__init__(
-            "System.Management.Automation.CommandOrigin",
-            string_map, **kwargs
-        )
+        super(CommandOrigin, self).__init__("System.Management.Automation.CommandOrigin", string_map, **kwargs)
 
 
 class PipelineResultTypes(Enum):
@@ -1690,7 +1558,11 @@ class PipelineResultTypes(Enum):
     ALL = 7  # Error, Warning, Verbose, Debug, Information streams
     NULL = 8  # redirect to nothing - pretty much the same as null
 
-    def __init__(self, protocol_version_2=False, **kwargs):
+    def __init__(
+        self,
+        protocol_version_2: bool = False,
+        **kwargs: typing.Any,
+    ) -> None:
         """
         [MS-PSRP] 2.2.3.31 PipelineResultTypes
         https://msdn.microsoft.com/en-us/library/ee938207.aspx
@@ -1704,58 +1576,48 @@ class PipelineResultTypes(Enum):
         """
         if protocol_version_2 is True:
             string_map = {
-                0: 'None',
-                1: 'Output',
-                2: 'Error',
-                3: 'Output, Error',
+                0: "None",
+                1: "Output",
+                2: "Error",
+                3: "Output, Error",
             }
         else:
             string_map = {
-                0: 'None',
-                1: 'Output',
-                2: 'Error',
-                3: 'Warning',
-                4: 'Verbose',
-                5: 'Debug',
-                6: 'Information',
-                7: 'All',
-                8: 'Null',
+                0: "None",
+                1: "Output",
+                2: "Error",
+                3: "Warning",
+                4: "Verbose",
+                5: "Debug",
+                6: "Information",
+                7: "All",
+                8: "Null",
             }
         super(PipelineResultTypes, self).__init__(
-            "System.Management.Automation.Runspaces.PipelineResultTypes",
-            string_map, **kwargs
+            "System.Management.Automation.Runspaces.PipelineResultTypes", string_map, **kwargs
         )
 
 
 class CultureInfo(ComplexObject):
-
     def __init__(self, **kwargs):
         super(CultureInfo, self).__init__()
 
         self._adapted_properties = (
-            ('lcid', ObjectMeta("I32", name="LCID")),
-            ('name', ObjectMeta("S", name="Name")),
-            ('display_name', ObjectMeta("S", name="DisplayName")),
-            ('ietf_language_tag', ObjectMeta("S", name="IetfLanguageTag")),
-            ('three_letter_iso_name', ObjectMeta(
-                "S", name="ThreeLetterISOLanguageName"
-            )),
-            ('three_letter_windows_name', ObjectMeta(
-                "S", name="ThreeLetterWindowsLanguageName"
-            )),
-            ('two_letter_iso_language_name', ObjectMeta(
-                "S", name="TwoLetterISOLanguageName"
-            )),
+            ("lcid", ObjectMeta("I32", name="LCID")),
+            ("name", ObjectMeta("S", name="Name")),
+            ("display_name", ObjectMeta("S", name="DisplayName")),
+            ("ietf_language_tag", ObjectMeta("S", name="IetfLanguageTag")),
+            ("three_letter_iso_name", ObjectMeta("S", name="ThreeLetterISOLanguageName")),
+            ("three_letter_windows_name", ObjectMeta("S", name="ThreeLetterWindowsLanguageName")),
+            ("two_letter_iso_language_name", ObjectMeta("S", name="TwoLetterISOLanguageName")),
         )
-        self.lcid = kwargs.get('lcid')
-        self.name = kwargs.get('name')
-        self.display_name = kwargs.get('display_name')
-        self.ieft_language_tag = kwargs.get('ietf_language_tag')
-        self.three_letter_iso_name = kwargs.get('three_letter_iso_name')
-        self.three_letter_windows_name = \
-            kwargs.get('three_letter_windows_name')
-        self.two_letter_iso_language_name = \
-            kwargs.get('two_letter_iso_language_name')
+        self.lcid = kwargs.get("lcid")
+        self.name = kwargs.get("name")
+        self.display_name = kwargs.get("display_name")
+        self.ieft_language_tag = kwargs.get("ietf_language_tag")
+        self.three_letter_iso_name = kwargs.get("three_letter_iso_name")
+        self.three_letter_windows_name = kwargs.get("three_letter_windows_name")
+        self.two_letter_iso_language_name = kwargs.get("two_letter_iso_language_name")
 
 
 class ProgressRecordType(Enum):
@@ -1771,12 +1633,11 @@ class ProgressRecordType(Enum):
         :param value: The initial ProgressRecordType value to set
         """
         string_map = {
-            0: 'Processing',
-            1: 'Completed',
+            0: "Processing",
+            1: "Completed",
         }
         super(ProgressRecordType, self).__init__(
-            "System.Management.Automation.ProgressRecordType",
-            string_map, **kwargs
+            "System.Management.Automation.ProgressRecordType", string_map, **kwargs
         )
 
 
@@ -1792,11 +1653,7 @@ class SessionStateEntryVisibility(Enum):
 
         :param value: The initial SessionStateEntryVisibility value to set
         """
-        string_map = {
-            0: 'Public',
-            1: 'Private'
-        }
+        string_map = {0: "Public", 1: "Private"}
         super(SessionStateEntryVisibility, self).__init__(
-            "System.Management.Automation.SessionStateEntryVisibility",
-            string_map, **kwargs
+            "System.Management.Automation.SessionStateEntryVisibility", string_map, **kwargs
         )

--- a/src/pypsrp/encryption.py
+++ b/src/pypsrp/encryption.py
@@ -1,6 +1,7 @@
 import logging
 import re
 import struct
+import typing
 
 from pypsrp._utils import to_bytes
 from pypsrp.exceptions import WinRMError
@@ -16,11 +17,13 @@ class WinRMEncryption(object):
     KERBEROS = "application/HTTP-Kerberos-session-encrypted"
     SPNEGO = "application/HTTP-SPNEGO-session-encrypted"
 
-    def __init__(self, context, protocol):
+    def __init__(self, context: typing.Any, protocol: str) -> None:
         log.debug("Initialising WinRMEncryption helper for protocol %s" % protocol)
         self.context = context
         self.protocol = protocol
 
+        self._wrap: typing.Callable[[bytes], typing.Tuple[bytes, int]]
+        self._unwrap: typing.Callable[[bytes], bytes]
         if protocol == self.CREDSSP:
             self._wrap = self._wrap_credssp
             self._unwrap = self._unwrap_credssp
@@ -28,13 +31,12 @@ class WinRMEncryption(object):
             self._wrap = self._wrap_spnego
             self._unwrap = self._unwrap_spnego
 
-    def wrap_message(self, message):
+    def wrap_message(self, message: bytes) -> typing.Tuple[str, bytes]:
         log.debug("Wrapping message")
         if self.protocol == self.CREDSSP and len(message) > self.SIXTEEN_KB:
             content_type = "multipart/x-multi-encrypted"
             encrypted_msg = b""
-            chunks = [message[i:i + self.SIXTEEN_KB] for i in
-                      range(0, len(message), self.SIXTEEN_KB)]
+            chunks = [message[i : i + self.SIXTEEN_KB] for i in range(0, len(message), self.SIXTEEN_KB)]
             for chunk in chunks:
                 encrypted_chunk = self._wrap_message(chunk)
                 encrypted_msg += encrypted_chunk
@@ -47,7 +49,7 @@ class WinRMEncryption(object):
         log.debug("Created wrapped message of content type %s" % content_type)
         return content_type, encrypted_msg
 
-    def unwrap_message(self, message, boundary):
+    def unwrap_message(self, message: bytes, boundary: str) -> bytes:
         log.debug("Unwrapped message")
 
         # Talking to Exchange endpoints gives a non-compliant boundary that has a space between the -- {boundary}, not
@@ -63,88 +65,88 @@ class WinRMEncryption(object):
             expected_length = int(header.split(b"Length=")[1])
 
             # remove the end MIME block if it exists
-            payload = re.sub(to_bytes(r'--\s*%s--\r\n$') % to_bytes(boundary), b'', payload)
+            payload = re.sub(to_bytes(r"--\s*%s--\r\n$") % to_bytes(boundary), b"", payload)
 
             wrapped_data = payload.replace(b"\tContent-Type: application/octet-stream\r\n", b"")
             unwrapped_data = self._unwrap(wrapped_data)
             actual_length = len(unwrapped_data)
 
-            log.debug("Actual unwrapped length: %d, expected unwrapped length:"
-                      " %d" % (actual_length, expected_length))
+            log.debug("Actual unwrapped length: %d, expected unwrapped length: %d" % (actual_length, expected_length))
             if actual_length != expected_length:
-                raise WinRMError("The encrypted length from the server does "
-                                 "not match the expected length, decryption "
-                                 "failed, actual: %d != expected: %d"
-                                 % (actual_length, expected_length))
+                raise WinRMError(
+                    "The encrypted length from the server does "
+                    "not match the expected length, decryption "
+                    "failed, actual: %d != expected: %d" % (actual_length, expected_length)
+                )
             message += unwrapped_data
 
         return message
 
-    def _wrap_message(self, message):
+    def _wrap_message(self, message: bytes) -> bytes:
         wrapped_data, padding_length = self._wrap(message)
         msg_length = str(len(message) + padding_length)
 
-        payload = "\r\n".join([
-            self.MIME_BOUNDARY,
-            "\tContent-Type: %s" % self.protocol,
-            "\tOriginalContent: type=application/soap+xml;charset=UTF-8;Length=%s" % msg_length,
-            self.MIME_BOUNDARY,
-            "\tContent-Type: application/octet-stream",
-            ""
-        ])
-        payload = to_bytes(payload) + wrapped_data
+        payload = "\r\n".join(
+            [
+                self.MIME_BOUNDARY,
+                "\tContent-Type: %s" % self.protocol,
+                "\tOriginalContent: type=application/soap+xml;charset=UTF-8;Length=%s" % msg_length,
+                self.MIME_BOUNDARY,
+                "\tContent-Type: application/octet-stream",
+                "",
+            ]
+        )
+        return to_bytes(payload) + wrapped_data
 
-        return payload
-
-    def _wrap_spnego(self, data):
+    def _wrap_spnego(self, data: bytes) -> typing.Tuple[bytes, int]:
         header, wrapped_data, padding_length = self.context.wrap_winrm(data)
 
         return struct.pack("<i", len(header)) + header + wrapped_data, padding_length
 
-    def _wrap_credssp(self, data):
+    def _wrap_credssp(self, data: bytes) -> typing.Tuple[bytes, int]:
         wrapped_data = self.context.wrap(data)
         cipher_negotiated = self.context.tls_connection.get_cipher_name()
         trailer_length = self._credssp_trailer(len(data), cipher_negotiated)
 
         return struct.pack("<i", trailer_length) + wrapped_data, 0
 
-    def _unwrap_spnego(self, data):
+    def _unwrap_spnego(self, data: bytes) -> bytes:
         header_length = struct.unpack("<i", data[:4])[0]
-        header = data[4:4 + header_length]
-        wrapped_data = data[4 + header_length:]
+        header = data[4 : 4 + header_length]
+        wrapped_data = data[4 + header_length :]
 
         data = self.context.unwrap_winrm(header, wrapped_data)
 
         return data
 
-    def _unwrap_credssp(self, data):
+    def _unwrap_credssp(self, data: bytes) -> bytes:
         wrapped_data = data[4:]
         data = self.context.unwrap(wrapped_data)
 
         return data
 
-    def _credssp_trailer(self, msg_len, cipher_suite):
+    def _credssp_trailer(
+        self,
+        msg_len: int,
+        cipher_suite: str,
+    ) -> int:
         # On Windows this is derived from SecPkgContext_StreamSizes, this is
         # not available on other platforms so we need to calculate it manually
-        log.debug("Attempting to get CredSSP trailer length for msg of "
-                  "length %d with cipher %s" % (msg_len, cipher_suite))
+        log.debug(
+            "Attempting to get CredSSP trailer length for msg of length %d with cipher %s" % (msg_len, cipher_suite)
+        )
 
-        if re.match(r'^.*-GCM-[\w\d]*$', cipher_suite):
+        if re.match(r"^.*-GCM-[\w\d]*$", cipher_suite):
             # GCM has a fixed length of 16 bytes
             trailer_length = 16
         else:
             # For other cipher suites, trailer size == len(hmac) + len(padding)
             # the padding it the length required by the chosen block cipher
-            hash_algorithm = cipher_suite.split('-')[-1]
+            hash_algorithm = cipher_suite.split("-")[-1]
 
             # while there are other algorithms, SChannel doesn't support them
             # as of yet so we just keep to this list
-            hash_length = {
-                'MD5': 16,
-                'SHA': 20,
-                'SHA256': 32,
-                'SHA384': 48
-            }.get(hash_algorithm, 0)
+            hash_length = {"MD5": 16, "SHA": 20, "SHA256": 32, "SHA384": 48}.get(hash_algorithm, 0)
 
             pre_pad_length = msg_len + hash_length
             if "RC4" in cipher_suite:

--- a/src/pypsrp/exceptions.py
+++ b/src/pypsrp/exceptions.py
@@ -1,6 +1,8 @@
 # Copyright: (c) 2018, Jordan Borean (@jborean93) <jborean93@gmail.com>
 # MIT License (see LICENSE or https://opensource.org/licenses/MIT)
 
+import typing
+
 from pypsrp.complex_objects import PSInvocationState, RunspacePoolState
 
 
@@ -31,9 +33,11 @@ class WinRMTransportError(WinRMError):
 
     @property
     def message(self):
-        return "Bad %s response returned from the server. Code: %d, " \
-               "Content: '%s'"\
-               % (self.protocol.upper(), self.code, self.response_text)
+        return "Bad %s response returned from the server. Code: %d, Content: '%s'" % (
+            self.protocol.upper(),
+            self.code,
+            self.response_text,
+        )
 
     def __str__(self):
         return self.message
@@ -90,8 +94,7 @@ class WSManFaultError(WinRMError):
         if len(error_details) == 0:
             error_details.append("No details returned by the server")
 
-        error_msg = "Received a WSManFault message. (%s)" \
-                    % ", ".join(error_details)
+        error_msg = "Received a WSManFault message. (%s)" % ", ".join(error_details)
         return error_msg
 
     def __str__(self):
@@ -100,7 +103,7 @@ class WSManFaultError(WinRMError):
 
 # PSRP Exceptions below
 class _InvalidStateError(WinRMError):
-    _STATE_OBJ = None
+    _STATE_OBJ: typing.Optional[typing.Type] = None
 
     @property
     def current_state(self):
@@ -121,8 +124,11 @@ class _InvalidStateError(WinRMError):
         if not isinstance(expected_state, list):
             expected_state = [expected_state]
         exp_state = [str(self._STATE_OBJ(s)) for s in expected_state]
-        return "Cannot '%s' on the current state '%s', expecting state(s): " \
-               "'%s'" % (self.action, current_state, ", ".join(exp_state))
+        return "Cannot '%s' on the current state '%s', expecting state(s): '%s'" % (
+            self.action,
+            current_state,
+            ", ".join(exp_state),
+        )
 
     def __str__(self):
         return self.message

--- a/src/pypsrp/wsman.py
+++ b/src/pypsrp/wsman.py
@@ -6,48 +6,48 @@ from __future__ import division
 import ipaddress
 import logging
 import re
-import requests
+import typing
 import uuid
 import warnings
 import xml.etree.ElementTree as ET
+from xml.dom.minidom import Element
 
+import requests
 from requests.packages.urllib3.util.retry import Retry
 
+from pypsrp._utils import get_hostname, to_string, to_unicode
 from pypsrp.encryption import WinRMEncryption
-from pypsrp.exceptions import AuthenticationError, WinRMError, \
-    WinRMTransportError, WSManFaultError
+from pypsrp.exceptions import (
+    AuthenticationError,
+    WinRMError,
+    WinRMTransportError,
+    WSManFaultError,
+)
 from pypsrp.negotiate import HTTPNegotiateAuth
-from pypsrp._utils import to_string, to_unicode, get_hostname
 
 try:
     from requests_credssp import HttpCredSSPAuth
 except ImportError as err:  # pragma: no cover
-    _requests_credssp_import_error = (
-        "Cannot use CredSSP auth as requests-credssp is not installed: %s"
-        % err
-    )
+    _requests_credssp_import_error = "Cannot use CredSSP auth as requests-credssp is not installed: %s" % err
 
-    class HttpCredSSPAuth(object):
+    class HttpCredSSPAuth(object):  # type: ignore[no-redef] # https://github.com/python/mypy/issues/1153
         def __init__(self, *args, **kwargs):
             raise ImportError(_requests_credssp_import_error)
 
 
 log = logging.getLogger(__name__)
 
-SUPPORTED_AUTHS = ["basic", "certificate", "credssp", "kerberos",
-                   "negotiate", "ntlm"]
+SUPPORTED_AUTHS = ["basic", "certificate", "credssp", "kerberos", "negotiate", "ntlm"]
 
-AUTH_KWARGS = {
+AUTH_KWARGS: typing.Dict[str, typing.List[str]] = {
     "certificate": ["certificate_key_pem", "certificate_pem"],
-    "credssp": ["credssp_auth_mechanism", "credssp_disable_tlsv1_2",
-                "credssp_minimum_version"],
-    "negotiate": ["negotiate_delegate", "negotiate_hostname_override",
-                  "negotiate_send_cbt", "negotiate_service"],
+    "credssp": ["credssp_auth_mechanism", "credssp_disable_tlsv1_2", "credssp_minimum_version"],
+    "negotiate": ["negotiate_delegate", "negotiate_hostname_override", "negotiate_send_cbt", "negotiate_service"],
 }
 
 # [MS-WSMV] 2.2.1 Namespaces
 # https://msdn.microsoft.com/en-us/library/ee878420.aspx
-NAMESPACES = {
+NAMESPACES: typing.Dict[str, str] = {
     "s": "http://www.w3.org/2003/05/soap-envelope",
     "xs": "http://www.w3.org/2001/XMLSchema",
     "xsi": "http://www.w3.org/2001/XMLSchema-instance",
@@ -61,10 +61,8 @@ NAMESPACES = {
     "sub": "http://schemas.microsoft.com/wbem/wsman/1/subscription",
     "rsp": "http://schemas.microsoft.com/wbem/wsman/1/windows/shell",
     "m": "http://schemas.microsoft.com/wbem/wsman/1/machineid",
-    "cert": "http://schemas.microsoft.com/wbem/wsman/1/config/service/"
-            "certmapping",
-    "plugin": "http://schemas.microsoft.com/wbem/wsman/1/config/"
-              "PluginConfiguration",
+    "cert": "http://schemas.microsoft.com/wbem/wsman/1/config/service/certmapping",
+    "plugin": "http://schemas.microsoft.com/wbem/wsman/1/config/PluginConfiguration",
     "wsen": "http://schemas.xmlsoap.org/ws/2004/09/enumeration",
     "wsdl": "http://schemas.xmlsoap.org/wsdl",
     "wst": "http://schemas.xmlsoap.org/ws/2004/09/transfer",
@@ -83,53 +81,55 @@ class WSManAction(object):
     PUT = "http://schemas.xmlsoap.org/ws/2004/09/transfer/Put"
     PUT_RESPONSE = "http://schemas.xmlsoap.org/ws/2004/09/transfer/PutResponse"
     CREATE = "http://schemas.xmlsoap.org/ws/2004/09/transfer/Create"
-    CREATE_RESPONSE = "http://schemas.xmlsoap.org/ws/2004/09/transfer/" \
-                      "CreateResponse"
+    CREATE_RESPONSE = "http://schemas.xmlsoap.org/ws/2004/09/transfer/CreateResponse"
     DELETE = "http://schemas.xmlsoap.org/ws/2004/09/transfer/Delete"
-    DELETE_RESPONSE = "http://schemas.xmlsoap.org/ws/2004/09/transfer/" \
-                      "DeleteResponse"
+    DELETE_RESPONSE = "http://schemas.xmlsoap.org/ws/2004/09/transfer/DeleteResponse"
     ENUMERATE = "http://schemas.xmlsoap.org/ws/2004/09/enumeration/Enumerate"
-    ENUMERATE_RESPONSE = "http://schemas.xmlsoap.org/ws/2004/09/enumeration/" \
-                         "EnumerateResponse"
+    ENUMERATE_RESPONSE = "http://schemas.xmlsoap.org/ws/2004/09/enumeration/EnumerateResponse"
     PULL = "http://schemas.xmlsoap.org/ws/2004/09/enumeration/Pull"
-    PULL_RESPONSE = "http://schemas.xmlsoap.org/ws/2004/09/enumeration/" \
-                    "PullResponse"
+    PULL_RESPONSE = "http://schemas.xmlsoap.org/ws/2004/09/enumeration/PullResponse"
 
     # MS-WSMV URIs
     COMMAND = "http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Command"
-    COMMAND_RESPONSE = "http://schemas.microsoft.com/wbem/wsman/1/windows/" \
-                       "shell/CommandResponse"
+    COMMAND_RESPONSE = "http://schemas.microsoft.com/wbem/wsman/1/windows/shell/CommandResponse"
     CONNECT = "http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Connect"
-    CONNECT_RESPONSE = "http://schemas.microsoft.com/wbem/wsman/1/windows/" \
-                       "shell/ConnectResponse"
-    DISCONNECT = "http://schemas.microsoft.com/wbem/wsman/1/windows/shell/" \
-                 "Disconnect"
-    DISCONNECT_RESPONSE = "http://schemas.microsoft.com/wbem/wsman/1/" \
-                          "windows/shell/DisconnectResponse"
+    CONNECT_RESPONSE = "http://schemas.microsoft.com/wbem/wsman/1/windows/shell/ConnectResponse"
+    DISCONNECT = "http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Disconnect"
+    DISCONNECT_RESPONSE = "http://schemas.microsoft.com/wbem/wsman/1/windows/shell/DisconnectResponse"
     RECEIVE = "http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Receive"
-    RECEIVE_RESPONSE = "http://schemas.microsoft.com/wbem/wsman/1/windows/" \
-                       "shell/ReceiveResponse"
-    RECONNECT = "http://schemas.microsoft.com/wbem/wsman/1/windows/shell/" \
-                "Reconnect"
-    RECONNECT_RESPONSE = "http://schemas.microsoft.com/wbem/wsman/1/windows/" \
-                         "shell/ReconnectResponse"
+    RECEIVE_RESPONSE = "http://schemas.microsoft.com/wbem/wsman/1/windows/shell/ReceiveResponse"
+    RECONNECT = "http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Reconnect"
+    RECONNECT_RESPONSE = "http://schemas.microsoft.com/wbem/wsman/1/windows/shell/ReconnectResponse"
     SEND = "http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Send"
-    SEND_RESPONSE = "http://schemas.microsoft.com/wbem/wsman/1/windows/" \
-                    "shell/SendResponse"
+    SEND_RESPONSE = "http://schemas.microsoft.com/wbem/wsman/1/windows/shell/SendResponse"
     SIGNAL = "http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Signal"
-    SIGNAL_RESPONSE = "http://schemas.microsoft.com/wbem/wsman/1/windows/" \
-                      "shell/SignalResponse"
+    SIGNAL_RESPONSE = "http://schemas.microsoft.com/wbem/wsman/1/windows/shell/SignalResponse"
 
 
 class WSMan(object):
-
-    def __init__(self, server, max_envelope_size=153600, operation_timeout=20,
-                 port=None, username=None, password=None, ssl=True,
-                 path="wsman", auth="negotiate", cert_validation=True,
-                 connection_timeout=30, encryption='auto', proxy=None,
-                 no_proxy=False, locale='en-US', data_locale=None,
-                 read_timeout=30, reconnection_retries=0,
-                 reconnection_backoff=2.0, **kwargs):
+    def __init__(
+        self,
+        server: str,
+        max_envelope_size: int = 153600,
+        operation_timeout: int = 20,
+        port: typing.Optional[int] = None,
+        username: typing.Optional[str] = None,
+        password: typing.Optional[str] = None,
+        ssl: bool = True,
+        path: str = "wsman",
+        auth: str = "negotiate",
+        cert_validation: bool = True,
+        connection_timeout: int = 30,
+        encryption: str = "auto",
+        proxy: typing.Optional[str] = None,
+        no_proxy: bool = False,
+        locale: str = "en-US",
+        data_locale: typing.Optional[str] = None,
+        read_timeout: int = 30,
+        reconnection_retries: int = 0,
+        reconnection_backoff: float = 2.0,
+        **kwargs: typing.Any,
+    ) -> None:
         """
         Class that handles WSMan transport over HTTP. This exposes a method per
         action that takes in a resource and the header metadata required by
@@ -204,20 +204,31 @@ class WSMan(object):
             negotiate_service: Override the service used when building the
                 server SPN, default='WSMAN'
         """
-        log.debug("Initialising WSMan class with maximum envelope size of %d "
-                  "and operation timeout of %s"
-                  % (max_envelope_size, operation_timeout))
+        log.debug(
+            "Initialising WSMan class with maximum envelope size of %d "
+            "and operation timeout of %s" % (max_envelope_size, operation_timeout)
+        )
         self.session_id = str(uuid.uuid4())
         self.locale = locale
-        self.data_locale = data_locale
-        if self.data_locale is None:
-            self.data_locale = self.locale
-        self.transport = _TransportHTTP(server, port, username, password, ssl,
-                                        path, auth, cert_validation,
-                                        connection_timeout, encryption, proxy,
-                                        no_proxy, read_timeout,
-                                        reconnection_retries,
-                                        reconnection_backoff, **kwargs)
+        self.data_locale = self.locale if data_locale is None else data_locale
+        self.transport = _TransportHTTP(
+            server,
+            port,
+            username,
+            password,
+            ssl,
+            path,
+            auth,
+            cert_validation,
+            connection_timeout,
+            encryption,
+            proxy,
+            no_proxy,
+            read_timeout,
+            reconnection_retries,
+            reconnection_backoff,
+            **kwargs,
+        )
         self.max_envelope_size = max_envelope_size
         self.operation_timeout = operation_timeout
 
@@ -240,96 +251,167 @@ class WSMan(object):
         # this information for you.
         self.max_payload_size = self._calc_envelope_size(max_envelope_size)
 
-    def __enter__(self):
+    def __enter__(self) -> "WSMan":
         return self
 
     def __exit__(self, type, value, traceback):
         self.close()
 
-    def command(self, resource_uri, resource, option_set=None,
-                selector_set=None, timeout=None):
-        res = self.invoke(WSManAction.COMMAND, resource_uri, resource,
-                          option_set, selector_set, timeout)
-        return res.find("s:Body", namespaces=NAMESPACES)
+    def command(
+        self,
+        resource_uri: str,
+        resource: ET.Element,
+        option_set: typing.Optional["OptionSet"] = None,
+        selector_set: typing.Optional["SelectorSet"] = None,
+        timeout: typing.Optional[int] = None,
+    ) -> ET.Element:
+        res = self.invoke(WSManAction.COMMAND, resource_uri, resource, option_set, selector_set, timeout)
+        return res.find("s:Body", namespaces=NAMESPACES)  # type: ignore[return-value] # WSMan always has this present
 
-    def connect(self, resource_uri, resource, option_set=None,
-                selector_set=None, timeout=None):
-        res = self.invoke(WSManAction.CONNECT, resource_uri, resource,
-                          option_set, selector_set, timeout)
-        return res.find("s:Body", namespaces=NAMESPACES)
+    def connect(
+        self,
+        resource_uri: str,
+        resource: ET.Element,
+        option_set: typing.Optional["OptionSet"] = None,
+        selector_set: typing.Optional["SelectorSet"] = None,
+        timeout: typing.Optional[int] = None,
+    ) -> ET.Element:
+        res = self.invoke(WSManAction.CONNECT, resource_uri, resource, option_set, selector_set, timeout)
+        return res.find("s:Body", namespaces=NAMESPACES)  # type: ignore[return-value] # WSMan always has this present
 
-    def create(self, resource_uri, resource, option_set=None,
-               selector_set=None, timeout=None):
-        res = self.invoke(WSManAction.CREATE, resource_uri, resource,
-                          option_set, selector_set, timeout)
-        return res.find("s:Body", namespaces=NAMESPACES)
+    def create(
+        self,
+        resource_uri: str,
+        resource: ET.Element,
+        option_set: typing.Optional["OptionSet"] = None,
+        selector_set: typing.Optional["SelectorSet"] = None,
+        timeout: typing.Optional[int] = None,
+    ) -> ET.Element:
+        res = self.invoke(WSManAction.CREATE, resource_uri, resource, option_set, selector_set, timeout)
+        return res.find("s:Body", namespaces=NAMESPACES)  # type: ignore[return-value] # WSMan always has this present
 
-    def disconnect(self, resource_uri, resource, option_set=None,
-                   selector_set=None, timeout=None):
-        res = self.invoke(WSManAction.DISCONNECT, resource_uri, resource,
-                          option_set, selector_set, timeout)
-        return res.find("s:Body", namespaces=NAMESPACES)
+    def disconnect(
+        self,
+        resource_uri: str,
+        resource: ET.Element,
+        option_set: typing.Optional["OptionSet"] = None,
+        selector_set: typing.Optional["SelectorSet"] = None,
+        timeout: typing.Optional[int] = None,
+    ) -> ET.Element:
+        res = self.invoke(WSManAction.DISCONNECT, resource_uri, resource, option_set, selector_set, timeout)
+        return res.find("s:Body", namespaces=NAMESPACES)  # type: ignore[return-value] # WSMan always has this present
 
-    def delete(self, resource_uri, resource=None, option_set=None,
-               selector_set=None, timeout=None):
-        res = self.invoke(WSManAction.DELETE, resource_uri, resource,
-                          option_set, selector_set, timeout)
-        return res.find("s:Body", namespaces=NAMESPACES)
+    def delete(
+        self,
+        resource_uri: str,
+        resource: typing.Optional[ET.Element] = None,
+        option_set: typing.Optional["OptionSet"] = None,
+        selector_set: typing.Optional["SelectorSet"] = None,
+        timeout: typing.Optional[int] = None,
+    ) -> ET.Element:
+        res = self.invoke(WSManAction.DELETE, resource_uri, resource, option_set, selector_set, timeout)
+        return res.find("s:Body", namespaces=NAMESPACES)  # type: ignore[return-value] # WSMan always has this present
 
-    def enumerate(self, resource_uri, resource=None, option_set=None,
-                  selector_set=None, timeout=None):
-        res = self.invoke(WSManAction.ENUMERATE, resource_uri, resource,
-                          option_set, selector_set, timeout)
-        return res.find("s:Body", namespaces=NAMESPACES)
+    def enumerate(
+        self,
+        resource_uri: str,
+        resource: typing.Optional[ET.Element] = None,
+        option_set: typing.Optional["OptionSet"] = None,
+        selector_set: typing.Optional["SelectorSet"] = None,
+        timeout: typing.Optional[int] = None,
+    ) -> ET.Element:
+        res = self.invoke(WSManAction.ENUMERATE, resource_uri, resource, option_set, selector_set, timeout)
+        return res.find("s:Body", namespaces=NAMESPACES)  # type: ignore[return-value] # WSMan always has this present
 
-    def get(self, resource_uri, resource=None, option_set=None,
-            selector_set=None, timeout=None):
-        res = self.invoke(WSManAction.GET, resource_uri, resource,
-                          option_set, selector_set, timeout)
-        return res.find("s:Body", namespaces=NAMESPACES)
+    def get(
+        self,
+        resource_uri: str,
+        resource: typing.Optional[ET.Element] = None,
+        option_set: typing.Optional["OptionSet"] = None,
+        selector_set: typing.Optional["SelectorSet"] = None,
+        timeout: typing.Optional[int] = None,
+    ) -> ET.Element:
+        res = self.invoke(WSManAction.GET, resource_uri, resource, option_set, selector_set, timeout)
+        return res.find("s:Body", namespaces=NAMESPACES)  # type: ignore[return-value] # WSMan always has this present
 
-    def pull(self, resource_uri, resource=None, option_set=None,
-             selector_set=None, timeout=None):
-        res = self.invoke(WSManAction.PULL, resource_uri, resource,
-                          option_set, selector_set, timeout)
-        return res.find("s:Body", namespaces=NAMESPACES)
+    def pull(
+        self,
+        resource_uri: str,
+        resource: typing.Optional[ET.Element] = None,
+        option_set: typing.Optional["OptionSet"] = None,
+        selector_set: typing.Optional["SelectorSet"] = None,
+        timeout: typing.Optional[int] = None,
+    ) -> ET.Element:
+        res = self.invoke(WSManAction.PULL, resource_uri, resource, option_set, selector_set, timeout)
+        return res.find("s:Body", namespaces=NAMESPACES)  # type: ignore[return-value] # WSMan always has this present
 
-    def put(self, resource_uri, resource=None, option_set=None,
-            selector_set=None, timeout=None):
-        res = self.invoke(WSManAction.PUT, resource_uri, resource,
-                          option_set, selector_set, timeout)
-        return res.find("s:Body", namespaces=NAMESPACES)
+    def put(
+        self,
+        resource_uri: str,
+        resource: typing.Optional[ET.Element] = None,
+        option_set: typing.Optional["OptionSet"] = None,
+        selector_set: typing.Optional["SelectorSet"] = None,
+        timeout: typing.Optional[int] = None,
+    ) -> ET.Element:
+        res = self.invoke(WSManAction.PUT, resource_uri, resource, option_set, selector_set, timeout)
+        return res.find("s:Body", namespaces=NAMESPACES)  # type: ignore[return-value] # WSMan always has this present
 
-    def receive(self, resource_uri, resource, option_set=None,
-                selector_set=None, timeout=None):
-        res = self.invoke(WSManAction.RECEIVE, resource_uri, resource,
-                          option_set, selector_set, timeout)
-        return res.find("s:Body", namespaces=NAMESPACES)
+    def receive(
+        self,
+        resource_uri: str,
+        resource: ET.Element,
+        option_set: typing.Optional["OptionSet"] = None,
+        selector_set: typing.Optional["SelectorSet"] = None,
+        timeout: typing.Optional[int] = None,
+    ) -> ET.Element:
+        res = self.invoke(WSManAction.RECEIVE, resource_uri, resource, option_set, selector_set, timeout)
+        return res.find("s:Body", namespaces=NAMESPACES)  # type: ignore[return-value] # WSMan always has this present
 
-    def reconnect(self, resource_uri, resource=None, option_set=None,
-                  selector_set=None, timeout=None):
-        res = self.invoke(WSManAction.RECONNECT, resource_uri, resource,
-                          option_set, selector_set, timeout)
-        return res.find("s:Body", namespaces=NAMESPACES)
+    def reconnect(
+        self,
+        resource_uri: str,
+        resource: typing.Optional[ET.Element] = None,
+        option_set: typing.Optional["OptionSet"] = None,
+        selector_set: typing.Optional["SelectorSet"] = None,
+        timeout: typing.Optional[int] = None,
+    ) -> ET.Element:
+        res = self.invoke(WSManAction.RECONNECT, resource_uri, resource, option_set, selector_set, timeout)
+        return res.find("s:Body", namespaces=NAMESPACES)  # type: ignore[return-value] # WSMan always has this present
 
-    def send(self, resource_uri, resource, option_set=None,
-             selector_set=None, timeout=None):
-        res = self.invoke(WSManAction.SEND, resource_uri, resource,
-                          option_set, selector_set, timeout)
-        return res.find("s:Body", namespaces=NAMESPACES)
+    def send(
+        self,
+        resource_uri: str,
+        resource: ET.Element,
+        option_set: typing.Optional["OptionSet"] = None,
+        selector_set: typing.Optional["SelectorSet"] = None,
+        timeout: typing.Optional[int] = None,
+    ) -> ET.Element:
+        res = self.invoke(WSManAction.SEND, resource_uri, resource, option_set, selector_set, timeout)
+        return res.find("s:Body", namespaces=NAMESPACES)  # type: ignore[return-value] # WSMan always has this present
 
-    def signal(self, resource_uri, resource, option_set=None,
-               selector_set=None, timeout=None):
-        res = self.invoke(WSManAction.SIGNAL, resource_uri, resource,
-                          option_set, selector_set, timeout)
-        return res.find("s:Body", namespaces=NAMESPACES)
+    def signal(
+        self,
+        resource_uri: str,
+        resource: ET.Element,
+        option_set: typing.Optional["OptionSet"] = None,
+        selector_set: typing.Optional["SelectorSet"] = None,
+        timeout: typing.Optional[int] = None,
+    ) -> ET.Element:
+        res = self.invoke(WSManAction.SIGNAL, resource_uri, resource, option_set, selector_set, timeout)
+        return res.find("s:Body", namespaces=NAMESPACES)  # type: ignore[return-value] # WSMan always has this present
 
-    def get_server_config(self, uri="config"):
+    def get_server_config(
+        self,
+        uri: str = "config",
+    ) -> ET.Element:
         resource_uri = "http://schemas.microsoft.com/wbem/wsman/1/%s" % uri
         log.debug("Getting server config with URI %s" % resource_uri)
         return self.get(resource_uri)
 
-    def update_max_payload_size(self, max_payload_size=None):
+    def update_max_payload_size(
+        self,
+        max_payload_size: typing.Optional[int] = None,
+    ) -> None:
         """
         Updates the MaxEnvelopeSize set on the current WSMan object for all
         future requests.
@@ -339,17 +421,23 @@ class WSMan(object):
         """
         if max_payload_size is None:
             config = self.get_server_config()
-            max_size_kb = config.find("cfg:Config/"
-                                      "cfg:MaxEnvelopeSizekb",
-                                      namespaces=NAMESPACES).text
-            max_payload_size = int(max_size_kb) * 1024
+            max_size_kb_et = config.find("cfg:Config/cfg:MaxEnvelopeSizekb", namespaces=NAMESPACES)
+            max_size_kb = max_size_kb_et.text if max_size_kb_et is not None else ""
+            max_payload_size = int(max_size_kb or "0") * 1024
 
         max_envelope_size = self._calc_envelope_size(max_payload_size)
         self.max_envelope_size = max_payload_size
         self.max_payload_size = max_envelope_size
 
-    def invoke(self, action, resource_uri, resource, option_set=None,
-               selector_set=None, timeout=None):
+    def invoke(
+        self,
+        action: str,
+        resource_uri: str,
+        resource: typing.Optional[ET.Element],
+        option_set: typing.Optional["OptionSet"] = None,
+        selector_set: typing.Optional["SelectorSet"] = None,
+        timeout: typing.Optional[int] = None,
+    ) -> ET.Element:
         """
         Send a generic WSMan request to the host.
 
@@ -365,19 +453,18 @@ class WSMan(object):
             the request, this should be an int in seconds.
         :return: The ET Element of the response XML from the server
         """
-        s = NAMESPACES['s']
+        s = NAMESPACES["s"]
         envelope = ET.Element("{%s}Envelope" % s)
 
-        header = self._create_header(action, resource_uri, option_set,
-                                     selector_set, timeout)
+        message_id, header = self._create_header(action, resource_uri, option_set, selector_set, timeout)
+        message_id = f"uuid:{message_id}"
         envelope.append(header)
 
         body = ET.SubElement(envelope, "{%s}Body" % s)
         if resource is not None:
             body.append(resource)
 
-        message_id = header.find("wsa:MessageID", namespaces=NAMESPACES).text
-        xml = ET.tostring(envelope, encoding='utf-8', method='xml')
+        xml = ET.tostring(envelope, encoding="utf-8", method="xml")
 
         try:
             response = self.transport.send(xml)
@@ -387,43 +474,46 @@ class WSMan(object):
                 raise self._parse_wsman_fault(err.response_text)
             except ET.ParseError:
                 # no XML message is present so not a WSManFault error
-                log.error("Failed to parse WSManFault message on WinRM error"
-                          " response, raising original WinRMTransportError")
+                log.error(
+                    "Failed to parse WSManFault message on WinRM error"
+                    " response, raising original WinRMTransportError"
+                )
                 raise err
 
         response_xml = ET.fromstring(response)
-        relates_to = response_xml.find("s:Header/wsa:RelatesTo",
-                                       namespaces=NAMESPACES).text
+        relates_to_et = response_xml.find("s:Header/wsa:RelatesTo", namespaces=NAMESPACES)
+        relates_to = relates_to_et.text if relates_to_et is not None else ""
 
         if message_id != relates_to:
-            raise WinRMError("Received related id does not match related "
-                             "expected message id: Sent: %s, Received: %s"
-                             % (message_id, relates_to))
+            raise WinRMError(
+                "Received related id does not match related "
+                "expected message id: Sent: %s, Received: %s" % (message_id, relates_to)
+            )
         return response_xml
 
-    def _calc_envelope_size(self, max_envelope_size):
+    def _calc_envelope_size(
+        self,
+        max_envelope_size: int,
+    ) -> int:
         # get a mock Header which should cover most cases where large fragments
         # are used
         empty_uuid = "00000000-0000-0000-0000-000000000000"
 
         selector_set = SelectorSet()
         selector_set.add_option("ShellId", empty_uuid)
-        header = self._create_header(
-            WSManAction.SEND,
-            "http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd",
-            selector_set=selector_set
+        _, header = self._create_header(
+            WSManAction.SEND, "http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd", selector_set=selector_set
         )
 
         # get a skeleton Body to calculate the size without the payload
-        rsp = NAMESPACES['rsp']
+        rsp = NAMESPACES["rsp"]
         send = ET.Element("{%s}Send" % rsp)
-        ET.SubElement(send, "{%s}Stream" % rsp, Name="stdin",
-                      CommandId=empty_uuid).text = ""
+        ET.SubElement(send, "{%s}Stream" % rsp, Name="stdin", CommandId=empty_uuid).text = ""
 
-        envelope = ET.Element("{%s}Envelope" % NAMESPACES['s'])
+        envelope = ET.Element("{%s}Envelope" % NAMESPACES["s"])
         envelope.append(header)
         envelope.append(send)
-        envelope = ET.tostring(envelope, encoding='utf-8', method='xml')
+        envelope = ET.tostring(envelope, encoding="utf-8", method="xml")
 
         # add the Header and Envelope and pad some extra bytes to cover
         # slightly different scenarios, multiple options, different body types
@@ -438,72 +528,57 @@ class WSMan(object):
         base64_size = int(max_bytes_size / 4 * 3)
         return base64_size
 
-    def _create_header(self, action, resource_uri, option_set=None,
-                       selector_set=None, timeout=None):
-        log.debug("Creating WSMan header (Action: %s, Resource URI: %s, "
-                  "Option Set: %s, Selector Set: %s"
-                  % (action, resource_uri, option_set, selector_set))
-        s = NAMESPACES['s']
-        wsa = NAMESPACES['wsa']
-        wsman = NAMESPACES['wsman']
-        wsmv = NAMESPACES['wsmv']
-        xml = NAMESPACES['xml']
+    def _create_header(
+        self,
+        action: str,
+        resource_uri: str,
+        option_set: typing.Optional["OptionSet"] = None,
+        selector_set: typing.Optional["SelectorSet"] = None,
+        timeout: typing.Optional[int] = None,
+    ) -> typing.Tuple[str, ET.Element]:
+        log.debug(
+            "Creating WSMan header (Action: %s, Resource URI: %s, "
+            "Option Set: %s, Selector Set: %s" % (action, resource_uri, option_set, selector_set)
+        )
+        s = NAMESPACES["s"]
+        wsa = NAMESPACES["wsa"]
+        wsman = NAMESPACES["wsman"]
+        wsmv = NAMESPACES["wsmv"]
+        xml = NAMESPACES["xml"]
 
         header = ET.Element("{%s}Header" % s)
 
-        ET.SubElement(
-            header,
-            "{%s}Action" % wsa,
-            attrib={"{%s}mustUnderstand" % s: "true"}
-        ).text = action
+        ET.SubElement(header, "{%s}Action" % wsa, attrib={"{%s}mustUnderstand" % s: "true"}).text = action
 
         ET.SubElement(
             header,
             "{%s}DataLocale" % wsmv,
-            attrib={"{%s}mustUnderstand" % s: "false",
-                    "{%s}lang" % xml: self.data_locale}
+            attrib={"{%s}mustUnderstand" % s: "false", "{%s}lang" % xml: self.data_locale},
         )
 
         ET.SubElement(
-            header,
-            "{%s}Locale" % wsman,
-            attrib={"{%s}mustUnderstand" % s: "false",
-                    "{%s}lang" % xml: self.locale}
+            header, "{%s}Locale" % wsman, attrib={"{%s}mustUnderstand" % s: "false", "{%s}lang" % xml: self.locale}
         )
 
-        ET.SubElement(
-            header,
-            "{%s}MaxEnvelopeSize" % wsman,
-            attrib={"{%s}mustUnderstand" % s: "true"}
-        ).text = str(self.max_envelope_size)
+        ET.SubElement(header, "{%s}MaxEnvelopeSize" % wsman, attrib={"{%s}mustUnderstand" % s: "true"}).text = str(
+            self.max_envelope_size
+        )
 
-        ET.SubElement(header, "{%s}MessageID" % wsa).text = \
-            "uuid:%s" % str(uuid.uuid4()).upper()
+        message_id = str(uuid.uuid4()).upper()
+        ET.SubElement(header, "{%s}MessageID" % wsa).text = "uuid:%s" % message_id
 
-        ET.SubElement(
-            header,
-            "{%s}OperationTimeout" % wsman
-        ).text = "PT%sS" % str(timeout or self.operation_timeout)
+        ET.SubElement(header, "{%s}OperationTimeout" % wsman).text = "PT%sS" % str(timeout or self.operation_timeout)
 
         reply_to = ET.SubElement(header, "{%s}ReplyTo" % wsa)
         ET.SubElement(
-            reply_to,
-            "{%s}Address" % wsa,
-            attrib={"{%s}mustUnderstand" % s: "true"}
-        ).text = "http://schemas.xmlsoap.org/ws/2004/08/addressing/role/" \
-                 "anonymous"
+            reply_to, "{%s}Address" % wsa, attrib={"{%s}mustUnderstand" % s: "true"}
+        ).text = "http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous"
 
-        ET.SubElement(
-            header,
-            "{%s}ResourceURI" % wsman,
-            attrib={"{%s}mustUnderstand" % s: "true"}
-        ).text = resource_uri
+        ET.SubElement(header, "{%s}ResourceURI" % wsman, attrib={"{%s}mustUnderstand" % s: "true"}).text = resource_uri
 
-        ET.SubElement(
-            header,
-            "{%s}SessionId" % wsmv,
-            attrib={"{%s}mustUnderstand" % s: "false"}
-        ).text = "uuid:%s" % str(self.session_id).upper()
+        ET.SubElement(header, "{%s}SessionId" % wsmv, attrib={"{%s}mustUnderstand" % s: "false"}).text = (
+            "uuid:%s" % str(self.session_id).upper()
+        )
 
         ET.SubElement(header, "{%s}To" % wsa).text = self.transport.endpoint
 
@@ -513,15 +588,15 @@ class WSMan(object):
         if selector_set is not None:
             header.append(selector_set.pack())
 
-        return header
+        return message_id, header
 
-    def close(self):
+    def close(self) -> None:
         self.transport.close()
 
     @staticmethod
-    def _parse_wsman_fault(xml_text):
+    def _parse_wsman_fault(xml_text: str) -> WSManFaultError:
         xml = ET.fromstring(xml_text)
-        code = None
+        code: typing.Optional[typing.Union[str, int]] = None
         reason = None
         machine = None
         provider = None
@@ -530,72 +605,60 @@ class WSMan(object):
 
         fault = xml.find("s:Body/s:Fault", namespaces=NAMESPACES)
         if fault is not None:
-            code_info = fault.find("s:Code/s:Subcode/s:Value",
-                                   namespaces=NAMESPACES)
+            code_info = fault.find("s:Code/s:Subcode/s:Value", namespaces=NAMESPACES)
             if code_info is not None:
                 code = code_info.text
             else:
-                code_info = fault.find("s:Code/s:Value",
-                                       namespaces=NAMESPACES)
+                code_info = fault.find("s:Code/s:Value", namespaces=NAMESPACES)
                 if code_info is not None:
                     code = code_info.text
 
-            reason_info = fault.find("s:Reason/s:Text",
-                                     namespaces=NAMESPACES)
+            reason_info = fault.find("s:Reason/s:Text", namespaces=NAMESPACES)
             if reason_info is not None:
                 reason = reason_info.text
 
-        wsman_fault = fault.find("s:Detail/wsmanfault:WSManFault",
-                                 namespaces=NAMESPACES)
+        wsman_fault = fault.find("s:Detail/wsmanfault:WSManFault", namespaces=NAMESPACES) if fault else None
         if wsman_fault is not None:
-            code = wsman_fault.attrib.get('Code', code)
-            machine = wsman_fault.attrib.get('Machine')
+            code = wsman_fault.attrib.get("Code", code)
+            machine = wsman_fault.attrib.get("Machine")
 
-            message_info = wsman_fault.find("wsmanfault:Message",
-                                            namespaces=NAMESPACES)
+            message_info = wsman_fault.find("wsmanfault:Message", namespaces=NAMESPACES)
             if message_info is not None:
                 # message may still not be set, fall back to the existing
                 # reason value from the base soap Fault element
-                reason = message_info.text if message_info.text else reason
+                reason = message_info.text or reason
 
-            provider_info = wsman_fault.find("wsmanfault:Message/"
-                                             "wsmanfault:ProviderFault",
-                                             namespaces=NAMESPACES)
+            provider_info = wsman_fault.find("wsmanfault:Message/wsmanfault:ProviderFault", namespaces=NAMESPACES)
             if provider_info is not None:
-                provider = provider_info.attrib.get('provider')
-                provider_path = provider_info.attrib.get('path')
+                provider = provider_info.attrib.get("provider")
+                provider_path = provider_info.attrib.get("path")
                 provider_fault = provider_info.text
 
         # lastly try and cleanup the value of the parameters
         try:
-            code = int(code)
+            code = int(code or "")
         except (TypeError, ValueError):
             pass
 
-        try:
-            reason = reason.strip()
-        except AttributeError:
-            pass
+        reason = reason.strip() if reason else None
+        provider_fault = provider_fault.strip() if provider_fault else None
 
-        try:
-            provider_fault = provider_fault.strip()
-        except AttributeError:
-            pass
-
-        return WSManFaultError(code, machine, reason, provider,
-                               provider_path,
-                               provider_fault)
+        return WSManFaultError(code, machine, reason, provider, provider_path, provider_fault)
 
 
 class _WSManSet(object):
-
-    def __init__(self, element_name, child_element_name, must_understand):
+    def __init__(
+        self,
+        element_name: str,
+        child_element_name: str,
+        must_understand: bool,
+    ) -> None:
         self.element_name = element_name
         self.child_element_name = child_element_name
         self.must_understand = must_understand
-        self.values = []
+        self.values: typing.List[typing.Tuple[str, str, typing.Dict]] = []
 
-    def __str__(self):
+    def __str__(self) -> str:
         # can't just str({}) as the ordering is important
         entry_values = []
         for value in self.values:
@@ -604,46 +667,61 @@ class _WSManSet(object):
         string_value = "{%s}" % ", ".join(entry_values)
         return string_value
 
-    def add_option(self, name, value, attributes=None):
+    def add_option(
+        self,
+        name: str,
+        value: str,
+        attributes: typing.Optional[typing.Dict] = None,
+    ) -> None:
         attributes = attributes if attributes is not None else {}
         self.values.append((name, value, attributes))
 
-    def pack(self):
-        s = NAMESPACES['s']
-        wsman = NAMESPACES['wsman']
+    def pack(self) -> ET.Element:
+        s = NAMESPACES["s"]
+        wsman = NAMESPACES["wsman"]
         element = ET.Element("{%s}%s" % (wsman, self.element_name))
         if self.must_understand:
-            element.attrib['{%s}mustUnderstand' % s] = "true"
+            element.attrib["{%s}mustUnderstand" % s] = "true"
 
         for key, value, attributes in self.values:
-            ET.SubElement(element, "{%s}%s" % (wsman, self.child_element_name),
-                          Name=key,
-                          attrib=attributes).text = str(value)
+            ET.SubElement(element, "{%s}%s" % (wsman, self.child_element_name), Name=key, attrib=attributes).text = str(
+                value
+            )
 
         return element
 
 
 class OptionSet(_WSManSet):
-
-    def __init__(self):
+    def __init__(self) -> None:
         super(OptionSet, self).__init__("OptionSet", "Option", True)
 
 
 class SelectorSet(_WSManSet):
-
-    def __init__(self):
+    def __init__(self) -> None:
         super(SelectorSet, self).__init__("SelectorSet", "Selector", False)
 
 
 # this should not be used outside of this class
 class _TransportHTTP(object):
-
-    def __init__(self, server, port=None, username=None, password=None,
-                 ssl=True, path="wsman", auth="negotiate",
-                 cert_validation=True, connection_timeout=30,
-                 encryption='auto', proxy=None, no_proxy=False,
-                 read_timeout=30, reconnection_retries=0,
-                 reconnection_backoff=2.0, **kwargs):
+    def __init__(
+        self,
+        server: str,
+        port: typing.Optional[int] = None,
+        username: typing.Optional[str] = None,
+        password: typing.Optional[str] = None,
+        ssl: bool = True,
+        path: str = "wsman",
+        auth: str = "negotiate",
+        cert_validation: bool = True,
+        connection_timeout: int = 30,
+        encryption: str = "auto",
+        proxy: typing.Optional[str] = None,
+        no_proxy: bool = False,
+        read_timeout: int = 30,
+        reconnection_retries: int = 0,
+        reconnection_backoff: float = 2.0,
+        **kwargs: typing.Any,
+    ) -> None:
         self.server = server
         self.port = port if port is not None else (5986 if ssl else 5985)
         self.username = username
@@ -652,9 +730,10 @@ class _TransportHTTP(object):
         self.path = path
 
         if auth not in SUPPORTED_AUTHS:
-            raise ValueError("The specified auth '%s' is not supported, "
-                             "please select one of '%s'"
-                             % (auth, ", ".join(SUPPORTED_AUTHS)))
+            raise ValueError(
+                "The specified auth '%s' is not supported, "
+                "please select one of '%s'" % (auth, ", ".join(SUPPORTED_AUTHS))
+            )
         self.auth = auth
         self.cert_validation = cert_validation
         self.connection_timeout = connection_timeout
@@ -664,8 +743,7 @@ class _TransportHTTP(object):
 
         # determine the message encryption logic
         if encryption not in ["auto", "always", "never"]:
-            raise ValueError("The encryption value '%s' must be auto, "
-                             "always, or never" % encryption)
+            raise ValueError("The encryption value '%s' must be auto, always, or never" % encryption)
         enc_providers = ["credssp", "kerberos", "negotiate", "ntlm"]
         if ssl:
             # msg's are automatically encrypted with TLS, we only want message
@@ -685,32 +763,34 @@ class _TransportHTTP(object):
                 raise ValueError(
                     "Cannot use message encryption with auth '%s', either set "
                     "encryption='never', use ssl=True or use one of the "
-                    "following auth providers: %s"
-                    % (self.auth, ", ".join(enc_providers))
+                    "following auth providers: %s" % (self.auth, ", ".join(enc_providers))
                 )
-        self.encryption = None
+        self.encryption: typing.Optional[WinRMEncryption] = None
 
         self.proxy = proxy
         self.no_proxy = no_proxy
 
+        self.certificate_key_pem: typing.Optional[str] = None
+        self.certificate_pem: typing.Optional[str] = None
         for kwarg_list in AUTH_KWARGS.values():
             for kwarg in kwarg_list:
                 setattr(self, kwarg, kwargs.get(kwarg, None))
 
-        self.endpoint = self._create_endpoint(self.ssl, self.server, self.port,
-                                              self.path)
-        log.debug("Initialising HTTP transport for endpoint: %s, user: %s, "
-                  "auth: %s" % (self.endpoint, self.username, self.auth))
-        self.session = None
+        self.endpoint = self._create_endpoint(self.ssl, self.server, self.port, self.path)
+        log.debug(
+            "Initialising HTTP transport for endpoint: %s, user: %s, "
+            "auth: %s" % (self.endpoint, self.username, self.auth)
+        )
+        self.session: typing.Optional[requests.Session] = None
 
         # used when building tests, keep commented out
         # self._test_messages = []
 
-    def close(self):
+    def close(self) -> None:
         if self.session:
             self.session.close()
 
-    def send(self, message):
+    def send(self, message: bytes) -> bytes:
         hostname = get_hostname(self.endpoint)
         if self.session is None:
             self.session = self._build_session()
@@ -718,55 +798,55 @@ class _TransportHTTP(object):
             # need to send an initial blank message to setup the security
             # context required for encryption
             if self.wrap_required:
-                request = requests.Request('POST', self.endpoint, data=None)
+                request = requests.Request("POST", self.endpoint, data=None)
                 prep_request = self.session.prepare_request(request)
                 self._send_request(prep_request)
 
                 protocol = WinRMEncryption.SPNEGO
                 if isinstance(self.session.auth, HttpCredSSPAuth):
                     protocol = WinRMEncryption.CREDSSP
-                elif self.session.auth.contexts[hostname].response_auth_header == 'kerberos':
+                elif self.session.auth.contexts[hostname].response_auth_header == "kerberos":  # type: ignore[union-attr] # This should not happen
                     # When Kerberos (not Negotiate) was used, we need to send a special protocol value and not SPNEGO.
                     protocol = WinRMEncryption.KERBEROS
 
-                self.encryption = WinRMEncryption(self.session.auth.contexts[hostname], protocol)
+                self.encryption = WinRMEncryption(self.session.auth.contexts[hostname], protocol)  # type: ignore[union-attr] # This should not happen
 
-        log.debug("Sending message: %s" % message)
+        if log.isEnabledFor(logging.DEBUG):
+            log.debug("Sending message: %s" % message.decode("utf-8"))
         # for testing, keep commented out
         # self._test_messages.append({"request": message.decode('utf-8'),
         #                             "response": None})
 
         headers = self.session.headers
         if self.wrap_required:
-            content_type, payload = self.encryption.wrap_message(message)
-            type_header = '%s;protocol="%s";boundary="Encrypted Boundary"' \
-                          % (content_type, self.encryption.protocol)
-            headers.update({
-                'Content-Type': type_header,
-                'Content-Length': str(len(payload)),
-            })
+            content_type, payload = self.encryption.wrap_message(message)  # type: ignore[union-attr] # This should not happen
+            protocol = self.encryption.protocol if self.encryption else WinRMEncryption.SPNEGO
+            type_header = '%s;protocol="%s";boundary="Encrypted Boundary"' % (content_type, protocol)
+            headers.update(
+                {
+                    "Content-Type": type_header,
+                    "Content-Length": str(len(payload)),
+                }
+            )
         else:
             payload = message
-            headers['Content-Type'] = "application/soap+xml;charset=UTF-8"
+            headers["Content-Type"] = "application/soap+xml;charset=UTF-8"
 
-        request = requests.Request('POST', self.endpoint, data=payload,
-                                   headers=headers)
+        request = requests.Request("POST", self.endpoint, data=payload, headers=headers)
         prep_request = self.session.prepare_request(request)
         return self._send_request(prep_request)
 
-    def _send_request(self, request):
-        response = self.session.send(request, timeout=(
-            self.connection_timeout, self.read_timeout
-        ))
+    def _send_request(self, request: requests.PreparedRequest) -> bytes:
+        response = self.session.send(request, timeout=(self.connection_timeout, self.read_timeout))  # type: ignore[union-attr] # This should not happen
 
-        content_type = response.headers.get('content-type', "")
+        content_type = response.headers.get("content-type", "")
         if content_type.startswith("multipart/encrypted;") or content_type.startswith("multipart/x-multi-encrypted;"):
-            boundary = re.search('boundary=[''|\\"](.*)[''|\\"]', response.headers['content-type']).group(1)
-            response_content = self.encryption.unwrap_message(response.content, to_unicode(boundary))
+            boundary = re.search("boundary=[" '|\\"](.*)[' '|\\"]', response.headers["content-type"]).group(1)  # type: ignore[union-attr] # This should not happen
+            response_content = self.encryption.unwrap_message(response.content, to_unicode(boundary))  # type: ignore[union-attr] # This should not happen
             response_text = to_string(response_content)
         else:
             response_content = response.content
-            response_text = response.text if response_content else ''
+            response_text = response.text if response_content else ""
 
         log.debug("Received message: %s" % response_text)
         # for testing, keep commented out
@@ -776,56 +856,52 @@ class _TransportHTTP(object):
         except requests.HTTPError as err:
             response = err.response
             if response.status_code == 401:
-                raise AuthenticationError("Failed to authenticate the user %s "
-                                          "with %s"
-                                          % (self.username, self.auth))
+                raise AuthenticationError("Failed to authenticate the user %s with %s" % (self.username, self.auth))
             else:
                 code = response.status_code
-                raise WinRMTransportError('http', code, response_text)
+                raise WinRMTransportError("http", code, response_text)
 
         return response_content
 
-    def _build_session(self):
+    def _build_session(self) -> requests.Session:
         log.debug("Building requests session with auth %s" % self.auth)
         self._suppress_library_warnings()
 
         session = requests.Session()
-        session.headers['User-Agent'] = "Python PSRP Client"
+        session.headers["User-Agent"] = "Python PSRP Client"
 
         # requests defaults to 'Accept-Encoding: gzip, default' which normally doesn't matter on vanila WinRM but for
         # Exchange endpoints hosted on IIS they actually compress it with 1 of the 2 algorithms. By explicitly setting
         # identity we are telling the server not to transform (compress) the data using the HTTP methods which we don't
         # support. https://tools.ietf.org/html/rfc7231#section-5.3.4
-        session.headers['Accept-Encoding'] = 'identity'
+        session.headers["Accept-Encoding"] = "identity"
 
         # get the env requests settings
         session.trust_env = True
-        settings = session.merge_environment_settings(url=self.endpoint,
-                                                      proxies={},
-                                                      stream=None,
-                                                      verify=None,
-                                                      cert=None)
+        settings = session.merge_environment_settings(  # type: ignore[no-untyped-call] # Not in types-requests
+            url=self.endpoint, proxies={}, stream=None, verify=None, cert=None
+        )
 
         # set the proxy config
-        session.proxies = settings['proxies']
-        proxy_key = 'https' if self.ssl else 'http'
+        session.proxies = settings["proxies"]
+        proxy_key = "https" if self.ssl else "http"
         if self.proxy is not None:
             session.proxies = {
                 proxy_key: self.proxy,
             }
         elif self.no_proxy:
             session.proxies = {
-                proxy_key: False,
-                }
+                proxy_key: False,  # type: ignore[dict-item] # A boolean is expected here
+            }
 
         # Retry on connection errors, with a backoff factor
         retry_kwargs = {
-            'total': self.reconnection_retries,
-            'connect': self.reconnection_retries,
-            'status': self.reconnection_retries,
-            'read': 0,
-            'backoff_factor': self.reconnection_backoff,
-            'status_forcelist': (425, 429, 503),
+            "total": self.reconnection_retries,
+            "connect": self.reconnection_retries,
+            "status": self.reconnection_retries,
+            "read": 0,
+            "backoff_factor": self.reconnection_backoff,
+            "status_forcelist": (425, 429, 503),
         }
         try:
             retries = Retry(**retry_kwargs)
@@ -833,103 +909,103 @@ class _TransportHTTP(object):
             # Status was added in urllib3 >= 1.21 (Requests >= 2.14.0), remove
             # the status retry counter and try again. The user should upgrade
             # to a newer version
-            log.warning("Using an older requests version that without support "
-                        "for status retries, ignoring.", exc_info=True)
-            del retry_kwargs['status']
+            log.warning(
+                "Using an older requests version that without support for status retries, ignoring.", exc_info=True
+            )
+            del retry_kwargs["status"]
             retries = Retry(**retry_kwargs)
 
-        session.mount('http://', requests.adapters.HTTPAdapter(max_retries=retries))
-        session.mount('https://', requests.adapters.HTTPAdapter(max_retries=retries))
+        session.mount("http://", requests.adapters.HTTPAdapter(max_retries=retries))
+        session.mount("https://", requests.adapters.HTTPAdapter(max_retries=retries))
 
         # set cert validation config
         session.verify = self.cert_validation
 
         # if cert_validation is a bool (no path specified), not False and there
         # are env settings for verification, set those env settings
-        if isinstance(self.cert_validation, bool) and self.cert_validation \
-                and settings['verify'] is not None:
-            session.verify = settings['verify']
+        if isinstance(self.cert_validation, bool) and self.cert_validation and settings["verify"] is not None:
+            session.verify = settings["verify"]
 
         build_auth = getattr(self, "_build_auth_%s" % self.auth)
         build_auth(session)
         return session
 
-    def _build_auth_basic(self, session):
+    def _build_auth_basic(self, session: requests.Session) -> None:
         if self.username is None:
             raise ValueError("For basic auth, the username must be specified")
         if self.password is None:
             raise ValueError("For basic auth, the password must be specified")
 
-        session.auth = requests.auth.HTTPBasicAuth(username=self.username,
-                                                   password=self.password)
+        session.auth = requests.auth.HTTPBasicAuth(username=self.username, password=self.password)
 
-    def _build_auth_certificate(self, session):
+    def _build_auth_certificate(self, session: requests.Session) -> None:
         if self.certificate_key_pem is None:
-            raise ValueError("For certificate auth, the path to the "
-                             "certificate key pem file must be specified with "
-                             "certificate_key_pem")
+            raise ValueError(
+                "For certificate auth, the path to the "
+                "certificate key pem file must be specified with "
+                "certificate_key_pem"
+            )
         if self.certificate_pem is None:
-            raise ValueError("For certificate auth, the path to the "
-                             "certificate pem file must be specified with "
-                             "certificate_pem")
+            raise ValueError(
+                "For certificate auth, the path to the "
+                "certificate pem file must be specified with "
+                "certificate_pem"
+            )
         if self.ssl is False:
             raise ValueError("For certificate auth, SSL must be used")
 
         session.cert = (self.certificate_pem, self.certificate_key_pem)
-        session.headers['Authorization'] = "http://schemas.dmtf.org/wbem/" \
-                                           "wsman/1/wsman/secprofile/" \
-                                           "https/mutual"
+        session.headers["Authorization"] = "http://schemas.dmtf.org/wbem/wsman/1/wsman/secprofile/https/mutual"
 
-    def _build_auth_credssp(self, session):
+    def _build_auth_credssp(self, session: requests.Session) -> None:
         if self.username is None:
-            raise ValueError("For credssp auth, the username must be "
-                             "specified")
+            raise ValueError("For credssp auth, the username must be specified")
         if self.password is None:
-            raise ValueError("For credssp auth, the password must be "
-                             "specified")
+            raise ValueError("For credssp auth, the password must be specified")
 
-        kwargs = self._get_auth_kwargs('credssp')
-        session.auth = HttpCredSSPAuth(username=self.username,
-                                       password=self.password,
-                                       **kwargs)
+        kwargs = self._get_auth_kwargs("credssp")
+        session.auth = HttpCredSSPAuth(username=self.username, password=self.password, **kwargs)
 
-    def _build_auth_kerberos(self, session):
+    def _build_auth_kerberos(self, session: requests.Session) -> None:
         self._build_auth_negotiate(session, "kerberos")
 
-    def _build_auth_negotiate(self, session, auth_provider="negotiate"):
-        kwargs = self._get_auth_kwargs('negotiate')
+    def _build_auth_negotiate(self, session: requests.Session, auth_provider: str = "negotiate") -> None:
+        kwargs = self._get_auth_kwargs("negotiate")
 
-        session.auth = HTTPNegotiateAuth(username=self.username,
-                                         password=self.password,
-                                         auth_provider=auth_provider,
-                                         wrap_required=self.wrap_required,
-                                         **kwargs)
+        session.auth = HTTPNegotiateAuth(
+            username=self.username,
+            password=self.password,
+            auth_provider=auth_provider,
+            wrap_required=self.wrap_required,
+            **kwargs,
+        )
 
-    def _build_auth_ntlm(self, session):
+    def _build_auth_ntlm(self, session: requests.Session) -> None:
         self._build_auth_negotiate(session, "ntlm")
 
-    def _get_auth_kwargs(self, auth_provider):
+    def _get_auth_kwargs(self, auth_provider: str) -> typing.Dict[str, typing.Any]:
         kwargs = {}
         for kwarg in AUTH_KWARGS[auth_provider]:
             kwarg_value = getattr(self, kwarg, None)
             if kwarg_value is not None:
-                kwarg_key = kwarg[len(auth_provider) + 1:]
+                kwarg_key = kwarg[len(auth_provider) + 1 :]
                 kwargs[kwarg_key] = kwarg_value
 
         return kwargs
 
-    def _suppress_library_warnings(self):
+    def _suppress_library_warnings(self) -> None:
         # try to suppress known warnings from requests if possible
         try:
-            from requests.packages.urllib3.exceptions import \
-                InsecurePlatformWarning
-            warnings.simplefilter('ignore', category=InsecurePlatformWarning)
+            from requests.packages.urllib3.exceptions import InsecurePlatformWarning
+
+            warnings.simplefilter("ignore", category=InsecurePlatformWarning)
         except:  # NOQA: E722; # pragma: no cover
             pass
 
         try:
             from requests.packages.urllib3.exceptions import SNIMissingWarning
-            warnings.simplefilter('ignore', category=SNIMissingWarning)
+
+            warnings.simplefilter("ignore", category=SNIMissingWarning)
         except:  # NOQA: E722; # pragma: no cover
             pass
 
@@ -937,15 +1013,19 @@ class _TransportHTTP(object):
         # InsecureRequestWarning, since the user opted-in
         if self.cert_validation is False:
             try:
-                from requests.packages.urllib3.exceptions import \
-                    InsecureRequestWarning
-                warnings.simplefilter('ignore',
-                                      category=InsecureRequestWarning)
+                from requests.packages.urllib3.exceptions import InsecureRequestWarning
+
+                warnings.simplefilter("ignore", category=InsecureRequestWarning)
             except:  # NOQA: E722; # pragma: no cover
                 pass
 
     @staticmethod
-    def _create_endpoint(ssl, server, port, path):
+    def _create_endpoint(
+        ssl: bool,
+        server: str,
+        port: int,
+        path: str,
+    ) -> str:
         scheme = "https" if ssl else "http"
 
         # Check if the server is an IPv6 Address, enclose in [] if it is

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,22 +5,20 @@ import struct
 import time
 import uuid
 import xml.etree.ElementTree as ET
-import yaml
 
 import pytest
+import yaml
 
+from pypsrp._utils import to_bytes, to_string
 from pypsrp.exceptions import AuthenticationError, WinRMTransportError
 from pypsrp.powershell import Fragment
 from pypsrp.wsman import NAMESPACES, WSMan
-from pypsrp._utils import to_bytes, to_string
 
 from . import assert_xml_diff
 
 
 class TransportFake(object):
-
-    def __init__(self, test_name, server, port, username, password, ssl, path,
-                 auth):
+    def __init__(self, test_name, server, port, username, password, ssl, path, auth):
         """
         This is a fake transport stub that takes in known requests and responds
         back with the already created response. This is used in cases when a
@@ -37,28 +35,24 @@ class TransportFake(object):
         self.ssl = ssl
         self.path = path
         self.auth = auth
-        self.endpoint = "%s://%s:%d/%s" \
-                        % ("https" if ssl else "http", server, port, path)
+        self.endpoint = "%s://%s:%d/%s" % ("https" if ssl else "http", server, port, path)
         self.session = None
 
         # used in the test only
         for key, value in NAMESPACES.items():
             ET.register_namespace(key, value)
 
-        self._uuid_pattern = re.compile("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]"
-                                        "{4}-[0-9a-f]{4}-[0-9a-f]{12}", re.I)
+        self._uuid_pattern = re.compile("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", re.I)
         self._test_name = test_name
         self._msg_counter = 0
         self._psrp_fragments = {}  # used to store PSRP fragments as they come in
-        meta_path = os.path.join(os.path.dirname(__file__),
-                                 'responses/%s.yml' % test_name)
+        meta_path = os.path.join(os.path.dirname(__file__), "responses/%s.yml" % test_name)
 
         if os.path.exists(meta_path):
-            with open(meta_path, 'rb') as o:
+            with open(meta_path, "rb") as o:
                 self._test_meta = yaml.load(o, Loader=yaml.SafeLoader)
         else:
-            raise Exception("Test metadata yml file does not exist at %s"
-                            % meta_path)
+            raise Exception("Test metadata yml file does not exist at %s" % meta_path)
 
         self._test_msg_key = "messages"
 
@@ -67,76 +61,71 @@ class TransportFake(object):
 
     def send(self, message):
         current_msg = self._test_meta[self._test_msg_key][self._msg_counter]
-        actual = self._normalise_xml(message, generify=False,
-                                     psrp_fragment_type='actual')
+        actual = self._normalise_xml(message, generify=False, psrp_fragment_type="actual")
         expected = self._normalise_xml(
-            current_msg['request'],
-            overrides=current_msg.get('overrides', None),
-            psrp_fragment_type='expected'
+            current_msg["request"], overrides=current_msg.get("overrides", None), psrp_fragment_type="expected"
         )
-        failure_msg = "Message %d request for test %s does not match " \
-                      "expectation\nActual:   %s\nExpected: %s" \
-                      % (self._msg_counter, self._test_name, actual, expected)
+        failure_msg = "Message %d request for test %s does not match expectation\nActual:   %s\nExpected: %s" % (
+            self._msg_counter,
+            self._test_name,
+            actual,
+            expected,
+        )
         assert_xml_diff(actual, expected, msg=failure_msg)
 
         for obj_id in list(self._psrp_fragments.keys()):
             details = self._psrp_fragments[obj_id]
-            if not details['end']:
+            if not details["end"]:
                 continue
 
-            fragment_ids = list(details['actual'].keys())
+            fragment_ids = list(details["actual"].keys())
             fragment_ids.sort()
 
             actual_obj = b""
             expected_obj = b""
             for i in range(0, fragment_ids[-1] + 1):
-                actual_obj += details['actual'][i]
-                expected_obj += details['expected'][i]
+                actual_obj += details["actual"][i]
+                expected_obj += details["expected"][i]
 
             actual_destination = struct.unpack("<I", actual_obj[:4])[0]
             actual_message_type = struct.unpack("<I", actual_obj[4:8])[0]
-            actual_message = self._normalise_xml(actual_obj[40:],
-                                                 generify=False)
+            actual_message = self._normalise_xml(actual_obj[40:], generify=False)
             expected_destination = struct.unpack("<I", expected_obj[:4])[0]
             expected_message_type = struct.unpack("<I", expected_obj[4:8])[0]
-            expected_message = self._normalise_xml(expected_obj[40:],
-                                                   generify=False)
+            expected_message = self._normalise_xml(expected_obj[40:], generify=False)
 
             assert actual_destination == expected_destination
             assert actual_message_type == expected_message_type
 
             # Only do the XML compare if the message had data, otherwise just
             # compare the actual values
-            failure_msg = "PSRP Message object %d for test %s does not match " \
-                          "expectation\nActual:    %s\nExpected: %s" \
-                          % (obj_id, self._test_name, actual_message,
-                             expected_message)
+            failure_msg = (
+                "PSRP Message object %d for test %s does not match "
+                "expectation\nActual:    %s\nExpected: %s" % (obj_id, self._test_name, actual_message, expected_message)
+            )
             assert_xml_diff(actual_message, expected_message, msg=failure_msg)
 
             # Remove the fragments for the obj as we've verified them
             del self._psrp_fragments[obj_id]
 
-        response = self._normalise_xml(current_msg['response'])
+        response = self._normalise_xml(current_msg["response"])
         self._msg_counter += 1
 
         # check if test metadata indicates we want to raise an exception here
         # instead of returning the response
-        if 'transport_error' in current_msg.keys():
+        if "transport_error" in current_msg.keys():
             raise WinRMTransportError(
-                current_msg['transport_error']['protocol'],
-                current_msg['transport_error']['code'], response
+                current_msg["transport_error"]["protocol"], current_msg["transport_error"]["code"], response
             )
-        elif current_msg.get('auth_error', False):
-            raise AuthenticationError("Failed to authenticate the user %s "
-                                      "with %s" % (self.username, self.auth))
+        elif current_msg.get("auth_error", False):
+            raise AuthenticationError("Failed to authenticate the user %s with %s" % (self.username, self.auth))
 
-        if 'timeout' in current_msg.keys():
-            time.sleep(current_msg['timeout'])
+        if "timeout" in current_msg.keys():
+            time.sleep(current_msg["timeout"])
 
         return response
 
-    def _normalise_xml(self, xml, generify=True, overrides=None,
-                       psrp_fragment_type=None):
+    def _normalise_xml(self, xml, generify=True, overrides=None, psrp_fragment_type=None):
         if not xml:
             return xml
 
@@ -144,8 +133,7 @@ class TransportFake(object):
 
         if generify:
             # convert all UUID values to the blank UUID
-            xml = re.sub(self._uuid_pattern,
-                         "00000000-0000-0000-0000-000000000000", xml)
+            xml = re.sub(self._uuid_pattern, "00000000-0000-0000-0000-000000000000", xml)
 
             xml_obj = ET.fromstring(to_bytes(xml))
 
@@ -155,10 +143,10 @@ class TransportFake(object):
                 to_field.text = self.endpoint
 
             for override in overrides:
-                override_element = xml_obj.find(override['path'], NAMESPACES)
-                if override.get('text'):
-                    override_element.text = override['text']
-                attributes = override.get('attributes', {})
+                override_element = xml_obj.find(override["path"], NAMESPACES)
+                if override.get("text"):
+                    override_element.text = override["text"]
+                attributes = override.get("attributes", {})
                 for attr_key, attr_value in attributes.items():
                     override_element.attrib[attr_key] = attr_value
         else:
@@ -168,18 +156,15 @@ class TransportFake(object):
         # base64 encoded. We need to strip these out and compare them
         # separately once all the fragments have been received.
         if psrp_fragment_type:
-            creation_xml = xml_obj.find("s:Body/rsp:Shell/{http://schemas."
-                                        "microsoft.com/powershell}creationXml",
-                                        NAMESPACES)
+            creation_xml = xml_obj.find(
+                "s:Body/rsp:Shell/{http://schemas.microsoft.com/powershell}creationXml", NAMESPACES
+            )
             if creation_xml is not None:
-                creation_xml.text = self._generify_fragment(creation_xml.text,
-                                                            psrp_fragment_type)
+                creation_xml.text = self._generify_fragment(creation_xml.text, psrp_fragment_type)
 
-            connect_xml = xml_obj.find("s:Body/rsp:Connect/pwsh:connectXml",
-                                       NAMESPACES)
+            connect_xml = xml_obj.find("s:Body/rsp:Connect/pwsh:connectXml", NAMESPACES)
             if connect_xml is not None:
-                connect_xml.text = self._generify_fragment(connect_xml.text,
-                                                           psrp_fragment_type)
+                connect_xml.text = self._generify_fragment(connect_xml.text, psrp_fragment_type)
 
             # when resource uri is PowerShell we know the Send/Command messages
             # contain PSRP fragments and we need to generify them
@@ -189,20 +174,15 @@ class TransportFake(object):
                 res_uri = res_uri.text
 
             streams = xml_obj.findall("s:Body/rsp:Send/rsp:Stream", NAMESPACES)
-            if res_uri is not None and res_uri.startswith(exp_res_uri) and \
-                    len(streams) > 0:
+            if res_uri is not None and res_uri.startswith(exp_res_uri) and len(streams) > 0:
                 for stream in streams:
-                    stream.text = self._generify_fragment(stream.text,
-                                                          psrp_fragment_type)
+                    stream.text = self._generify_fragment(stream.text, psrp_fragment_type)
 
-            command = xml_obj.find("s:Body/rsp:CommandLine/rsp:Arguments",
-                                   NAMESPACES)
-            if res_uri is not None and res_uri.startswith(exp_res_uri) and \
-                    command is not None:
-                command.text = self._generify_fragment(command.text,
-                                                       psrp_fragment_type)
+            command = xml_obj.find("s:Body/rsp:CommandLine/rsp:Arguments", NAMESPACES)
+            if res_uri is not None and res_uri.startswith(exp_res_uri) and command is not None:
+                command.text = self._generify_fragment(command.text, psrp_fragment_type)
 
-        return to_string(ET.tostring(xml_obj, encoding='utf-8'))
+        return to_string(ET.tostring(xml_obj, encoding="utf-8"))
 
     def _simplify_namespaces(self, namespaces, element):
         namespaces.update(element.nsmap)
@@ -236,61 +216,56 @@ class TransportFake(object):
         while idx < len(f_data):
             frag = Fragment.unpack(f_data[idx:])[0]
 
-            length = struct.unpack(">I", f_data[idx + 17:idx + 21])[0]
-            m_data = f_data[idx + 21:idx + length + 21]
+            length = struct.unpack(">I", f_data[idx + 17 : idx + 21])[0]
+            m_data = f_data[idx + 21 : idx + length + 21]
 
             # We store the fragments for later comparison
             fragment_buffer = self._psrp_fragments.get(frag.object_id, None)
             if fragment_buffer is None:
-                fragment_buffer = {
-                    'actual': {},
-                    'expected': {},
-                    'end': False
-                }
+                fragment_buffer = {"actual": {}, "expected": {}, "end": False}
                 self._psrp_fragments[frag.object_id] = fragment_buffer
 
             fragment_buffer[fragment_type][frag.fragment_id] = m_data
             if frag.end:
-                fragment_buffer['end'] = True
+                fragment_buffer["end"] = True
 
             # We don't add the actual message to make the initial message
             # comparison easier
-            new_value += f_data[idx:idx + 21]
+            new_value += f_data[idx : idx + 21]
             idx += length + 21
-        return base64.b64encode(new_value).decode('utf-8')
+        return base64.b64encode(new_value).decode("utf-8")
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def wsman_conn(request, monkeypatch):
     test_params = request.param
     if not isinstance(test_params, list) or len(test_params) != 2:
-        raise Exception("Cannot run winrm_transport fixture without the "
-                        "allow real and test name set")
+        raise Exception("Cannot run winrm_transport fixture without the allow real and test name set")
 
     allow_real = test_params[0]
     test_name = test_params[1]
 
     # these need to be set to run against a proper server
-    username = os.environ.get('PYPSRP_USERNAME', None)
-    password = os.environ.get('PYPSRP_PASSWORD', None)
-    server = os.environ.get('PYPSRP_SERVER', None)
+    username = os.environ.get("PYPSRP_USERNAME", None)
+    password = os.environ.get("PYPSRP_PASSWORD", None)
+    server = os.environ.get("PYPSRP_SERVER", None)
 
     # these are optional vars that can further control the transport setup
-    auth = os.environ.get('PYPSRP_AUTH', 'negotiate')
-    port = int(os.environ.get('PYPSRP_PORT', '5986'))
+    auth = os.environ.get("PYPSRP_AUTH", "negotiate")
+    port = int(os.environ.get("PYPSRP_PORT", "5986"))
     ssl = port != 5985
 
-    if allow_real and username is not None and password is not None and \
-            server is not None:
-        wsman = WSMan(server, port=port, username=username, password=password,
-                      ssl=ssl, auth=auth, cert_validation=False)
+    if allow_real and username is not None and password is not None and server is not None:
+        wsman = WSMan(
+            server, port=port, username=username, password=password, ssl=ssl, auth=auth, cert_validation=False
+        )
     else:
         # Mock out UUID's so they are not a problem when comparing messages
         def mockuuid():
             return uuid.UUID("00000000-0000-0000-0000-000000000000")
-        monkeypatch.setattr(uuid, 'uuid4', mockuuid)
-        transport = TransportFake(test_name, "fakehost", port, "username",
-                                  "password", ssl, "wsman", auth)
+
+        monkeypatch.setattr(uuid, "uuid4", mockuuid)
+        transport = TransportFake(test_name, "fakehost", port, "username", "password", ssl, "wsman", auth)
         wsman = WSMan("")
         wsman.transport = transport
 
@@ -299,9 +274,7 @@ def wsman_conn(request, monkeypatch):
 
     # used as an easy way to be results for a test, requires the _test_messages
     # to be uncommented in pypsrp/wsman.py
-    test_messages = getattr(wsman.transport, '_test_messages', None)
+    test_messages = getattr(wsman.transport, "_test_messages", None)
     if test_messages is not None:
-        yaml_text = yaml.dump({"messages": test_messages},
-                              default_flow_style=False,
-                              width=9999)
+        yaml_text = yaml.dump({"messages": test_messages}, default_flow_style=False, width=9999)
         print(yaml_text)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,28 +1,18 @@
 import hashlib
 import os
 import tempfile
+from collections import OrderedDict
 
 import pytest
 
+from pypsrp._utils import to_unicode
 from pypsrp.client import Client
 from pypsrp.exceptions import WinRMError
 from pypsrp.powershell import PSDataStreams
 from pypsrp.wsman import WSMan
-from pypsrp._utils import to_unicode
-
-try:
-    from collections import OrderedDict
-except ImportError:  # pragma: no cover
-    from ordereddict import OrderedDict
-
-try:
-    from unittest.mock import MagicMock
-except ImportError:
-    from mock import MagicMock
 
 
 class TestClient(object):
-
     def _get_client(self, wsman):
         # the connection object was already created as part of test fixture
         # we need to apply it to the Client object and set the values so the
@@ -31,8 +21,7 @@ class TestClient(object):
         client.wsman = wsman
         return client
 
-    @pytest.mark.parametrize('wsman_conn',
-                             [[True, 'test_client_copy_file']], indirect=True)
+    @pytest.mark.parametrize("wsman_conn", [[True, "test_client_copy_file"]], indirect=True)
     def test_client_copy_file(self, wsman_conn):
         client = self._get_client(wsman_conn)
         test_string = b"abcdefghijklmnopqrstuvwxyz"
@@ -52,16 +41,12 @@ class TestClient(object):
             # verify the returned object is the full path
             assert actual.startswith("C:\\Users\\")
 
-            actual_content = client.execute_cmd(
-                "powershell.exe Get-Content %s" % actual
-            )[0].strip()
+            actual_content = client.execute_cmd("powershell.exe Get-Content %s" % actual)[0].strip()
             assert actual_content == to_unicode(test_string)
         finally:
             client.execute_cmd("powershell Remove-Item -Path '%s'" % actual)
 
-    @pytest.mark.parametrize('wsman_conn',
-                             [[True, 'test_client_copy_file_empty']],
-                             indirect=True)
+    @pytest.mark.parametrize("wsman_conn", [[True, "test_client_copy_file_empty"]], indirect=True)
     def test_client_copy_file_empty(self, wsman_conn):
         client = self._get_client(wsman_conn)
 
@@ -76,24 +61,24 @@ class TestClient(object):
             # verify the returned object is the full path
             assert actual.startswith("C:\\Users\\")
 
-            actual_content = client.execute_cmd(
-                "powershell.exe Get-Content %s" % actual
-            )[0].strip()
+            actual_content = client.execute_cmd("powershell.exe Get-Content %s" % actual)[0].strip()
             assert actual_content == ""
         finally:
             client.execute_cmd("powershell Remove-Item -Path '%s'" % actual)
 
-    @pytest.mark.parametrize('wsman_conn',
-                             # checks as to whether the correct number of calls
-                             # were sent and the remote requirements are too
-                             # variable to trust reliable
-                             [[False, 'test_client_copy_file_really_large']],
-                             indirect=True)
-    def test_client_copy_file_really_large(self, wsman_conn, monkeypatch):
+    @pytest.mark.parametrize(
+        "wsman_conn",
+        # checks as to whether the correct number of calls
+        # were sent and the remote requirements are too
+        # variable to trust reliable
+        [[False, "test_client_copy_file_really_large"]],
+        indirect=True,
+    )
+    def test_client_copy_file_really_large(self, wsman_conn, monkeypatch, mocker):
         # in a mocked context the calculated size differs on a few variables
         # we will mock out that call and return the ones used in our existing
         # responses
-        mock_calc = MagicMock()
+        mock_calc = mocker.MagicMock()
         mock_calc.return_value = 113955
         monkeypatch.setattr(WSMan, "_calc_envelope_size", mock_calc)
 
@@ -112,15 +97,12 @@ class TestClient(object):
         # verify the returned object is the full path
         assert actual == u"C:\\Users\\vagrant\\Documents\\test_file"
 
-    @pytest.mark.parametrize('wsman_conn',
-                             [[True, 'test_client_copy_file_failure']],
-                             indirect=True)
-    def test_client_copy_file_failure(self, wsman_conn, monkeypatch):
+    @pytest.mark.parametrize("wsman_conn", [[True, "test_client_copy_file_failure"]], indirect=True)
+    def test_client_copy_file_failure(self, wsman_conn, monkeypatch, mocker):
         # set to a hash that is not the actual to verify the script will
         # fail in a hash mismatch scenario
-        mock_hash = MagicMock()
-        mock_hash.return_value.hexdigest.return_value = \
-            "c3499c2729730a7f807efb8676a92dcb6f8a3f8f"
+        mock_hash = mocker.MagicMock()
+        mock_hash.return_value.hexdigest.return_value = "c3499c2729730a7f807efb8676a92dcb6f8a3f8f"
         monkeypatch.setattr(hashlib, "sha1", mock_hash)
 
         client = self._get_client(wsman_conn)
@@ -131,19 +113,22 @@ class TestClient(object):
             os.write(temp_file, test_string)
             with pytest.raises(WinRMError) as err:
                 actual = client.copy(path, "test_file")
-            expected_err = \
-                "Failed to copy file: Transport failure, hash mismatch\r\n" \
-                "Actual: 32d10c7b8cf96570ca04ce37f2a19d84240d3a89\r\n" \
+            expected_err = (
+                "Failed to copy file: Transport failure, hash mismatch\r\n"
+                "Actual: 32d10c7b8cf96570ca04ce37f2a19d84240d3a89\r\n"
                 "Expected: c3499c2729730a7f807efb8676a92dcb6f8a3f8f"
+            )
             assert expected_err in str(err.value)
         finally:
             os.close(temp_file)
             os.remove(path)
 
-    @pytest.mark.parametrize('wsman_conn',
-                             # Requires a specially crafted response to be returned
-                             [[False, 'test_client_copy_file_warning']],
-                             indirect=True)
+    @pytest.mark.parametrize(
+        "wsman_conn",
+        # Requires a specially crafted response to be returned
+        [[False, "test_client_copy_file_warning"]],
+        indirect=True,
+    )
     def test_client_copy_file_warning(self, wsman_conn):
         client = self._get_client(wsman_conn)
         test_string = b"abcdefghijklmnopqrstuvwxyz"
@@ -151,18 +136,23 @@ class TestClient(object):
         temp_file, path = tempfile.mkstemp()
         try:
             os.write(temp_file, test_string)
-            with pytest.warns(Warning, match="Failed to disable MaximumAllowedMemory input size: You cannot call a "
-                                             "method on a null-valued expression"):
+            with pytest.warns(
+                Warning,
+                match="Failed to disable MaximumAllowedMemory input size: You cannot call a "
+                "method on a null-valued expression",
+            ):
                 actual = client.copy(path, "test_file")
             client.execute_cmd("powershell Remove-Item -Path '%s'" % actual)
         finally:
             os.close(temp_file)
             os.remove(path)
 
-    @pytest.mark.parametrize('wsman_conn',
-                             # Tested against a specific user name
-                             [[False, 'test_client_copy_expand_vars']],
-                             indirect=True)
+    @pytest.mark.parametrize(
+        "wsman_conn",
+        # Tested against a specific user name
+        [[False, "test_client_copy_expand_vars"]],
+        indirect=True,
+    )
     def test_client_copy_expand_vars(self, wsman_conn):
         client = self._get_client(wsman_conn)
         test_string = b"abcdefghijklmnopqrstuvwxyz"
@@ -187,9 +177,7 @@ class TestClient(object):
         finally:
             client.execute_cmd("powershell Remove-Item -Path '%s'" % actual)
 
-    @pytest.mark.parametrize('wsman_conn',
-                             [[True, 'test_client_execute_cmd']],
-                             indirect=True)
+    @pytest.mark.parametrize("wsman_conn", [[True, "test_client_execute_cmd"]], indirect=True)
     def test_client_execute_cmd(self, wsman_conn):
         client = self._get_client(wsman_conn)
         actual = client.execute_cmd("dir")
@@ -203,19 +191,20 @@ class TestClient(object):
         assert actual_args[1] == u""
         assert actual_args[2] == 0
 
-    @pytest.mark.parametrize('wsman_conn',
-                             [[True, 'test_client_execute_cmd_environment']], indirect=True)
+    @pytest.mark.parametrize("wsman_conn", [[True, "test_client_execute_cmd_environment"]], indirect=True)
     def test_client_execute_cmd_environment(self, wsman_conn):
         client = self._get_client(wsman_conn)
 
-        env = OrderedDict([
-            ('string', 'string value'),
-            ('int', 1234),
-            ('bool', True),
-            ('double_quote', 'double " quote'),
-            ('single_quote', "single ' quote"),
-            ('hyphen - var', 'abc @ 123'),
-        ])
+        env = OrderedDict(
+            [
+                ("string", "string value"),
+                ("int", 1234),
+                ("bool", True),
+                ("double_quote", 'double " quote'),
+                ("single_quote", "single ' quote"),
+                ("hyphen - var", "abc @ 123"),
+            ]
+        )
         actual = client.execute_cmd("set", environment=env)
         actual_environment = actual[0].splitlines()
         for env_key, env_value in env.items():
@@ -223,36 +212,37 @@ class TestClient(object):
             assert actual_env is not None
             assert actual_env == "%s=%s" % (env_key, env_value)
 
-    @pytest.mark.parametrize('wsman_conn',
-                             [[True, 'test_client_execute_ps']], indirect=True)
+    @pytest.mark.parametrize("wsman_conn", [[True, "test_client_execute_ps"]], indirect=True)
     def test_client_execute_ps(self, wsman_conn):
         client = self._get_client(wsman_conn)
 
-        expected_stdout = u'winrm\nRunning\n\nStatus   Name               ' \
-                          u'DisplayName                           \n------' \
-                          u'   ----               -----------             ' \
-                          u'              \nRunning  winrm              Wi' \
-                          u'ndows Remote Management (WS-Manag...\n\n'
-        actual = client.execute_ps("$serv = Get-Service -Name winrm; "
-                                   "$serv.Name; $serv.Status; $serv")
+        expected_stdout = (
+            u"winrm\nRunning\n\nStatus   Name               "
+            u"DisplayName                           \n------"
+            u"   ----               -----------             "
+            u"              \nRunning  winrm              Wi"
+            u"ndows Remote Management (WS-Manag...\n\n"
+        )
+        actual = client.execute_ps("$serv = Get-Service -Name winrm; $serv.Name; $serv.Status; $serv")
         assert actual[0] == expected_stdout
         assert isinstance(actual[1], PSDataStreams)
         assert actual[2] is False
 
-    @pytest.mark.parametrize('wsman_conn',
-                             [[True, 'test_client_execute_ps_environment']], indirect=True)
+    @pytest.mark.parametrize("wsman_conn", [[True, "test_client_execute_ps_environment"]], indirect=True)
     def test_client_execute_ps_environment(self, wsman_conn):
         client = self._get_client(wsman_conn)
 
-        env = OrderedDict([
-            ('string', 'string value'),
-            ('int', 1234),
-            ('bool', True),
-            ('double_quote', 'double " quote'),
-            ('single_quote', "single ' quote"),
-            ('hyphen - var', 'abc @ 123'),
-            ('_-(){}[]<>*+-/\\?"''!@#$%^&|;:i,.`~0', '_-(){}[]<>*+-/\\?"''!@#$%^&|;:i,.`~0'),
-        ])
+        env = OrderedDict(
+            [
+                ("string", "string value"),
+                ("int", 1234),
+                ("bool", True),
+                ("double_quote", 'double " quote'),
+                ("single_quote", "single ' quote"),
+                ("hyphen - var", "abc @ 123"),
+                ('_-(){}[]<>*+-/\\?"' "!@#$%^&|;:i,.`~0", '_-(){}[]<>*+-/\\?"' "!@#$%^&|;:i,.`~0"),
+            ]
+        )
         actual = client.execute_ps("cmd.exe /c set", environment=env)
         actual_environment = actual[0].splitlines()
         for env_key, env_value in env.items():
@@ -260,9 +250,7 @@ class TestClient(object):
             assert actual_env is not None
             assert actual_env == "%s=%s" % (env_key, env_value)
 
-    @pytest.mark.parametrize('wsman_conn',
-                             [[True, 'test_client_execute_ps_failure']],
-                             indirect=True)
+    @pytest.mark.parametrize("wsman_conn", [[True, "test_client_execute_ps_failure"]], indirect=True)
     def test_client_execute_ps_failure(self, wsman_conn):
         client = self._get_client(wsman_conn)
 
@@ -270,17 +258,21 @@ class TestClient(object):
 
         assert actual[0] == u""
         assert len(actual[1].error) == 1
-        assert str(actual[1].error[0]) == \
-            "The term 'Get-ServiceTypo' is not recognized as the name of a " \
-            "cmdlet, function, script file, or operable program. Check the " \
-            "spelling of the name, or if a path was included, verify that " \
+        assert (
+            str(actual[1].error[0]) == "The term 'Get-ServiceTypo' is not recognized as the name of a "
+            "cmdlet, function, script file, or operable program. Check the "
+            "spelling of the name, or if a path was included, verify that "
             "the path is correct and try again."
+        )
         assert actual[2] is True
 
-    @pytest.mark.parametrize('wsman_conn',
-                             # means we don't need to create files on the
-                             # remote side
-                             [[False, 'test_client_fetch_file']], indirect=True)
+    @pytest.mark.parametrize(
+        "wsman_conn",
+        # means we don't need to create files on the
+        # remote side
+        [[False, "test_client_fetch_file"]],
+        indirect=True,
+    )
     def test_client_fetch_file(self, wsman_conn):
         client = self._get_client(wsman_conn)
 
@@ -292,9 +284,7 @@ class TestClient(object):
         os.remove(path)
         try:
             client.fetch("C:\\temp\\file.txt", path)
-            expected_hash = b"\x70\xe3\xbe\xa8\xcd\xb0\xd0\xc8" \
-                            b"\x83\xbc\xcf\xf5\x22\x89\x33\xd9" \
-                            b"\x33\xb8\x8a\x80"
+            expected_hash = b"\x70\xe3\xbe\xa8\xcd\xb0\xd0\xc8\x83\xbc\xcf\xf5\x22\x89\x33\xd9\x33\xb8\x8a\x80"
             hash = hashlib.sha1()
             with open(path, "rb") as temp_file:
                 while True:
@@ -308,40 +298,35 @@ class TestClient(object):
             if os.path.exists(path):
                 os.remove(path)
 
-    @pytest.mark.parametrize('wsman_conn',
-                             [[True, 'test_client_fetch_file_fail_dir']],
-                             indirect=True)
+    @pytest.mark.parametrize("wsman_conn", [[True, "test_client_fetch_file_fail_dir"]], indirect=True)
     def test_client_fetch_file_fail_dir(self, wsman_conn):
         client = self._get_client(wsman_conn)
         with pytest.raises(WinRMError) as err:
             client.fetch("C:\\Windows", "")
-        assert str(err.value) == \
-            "Failed to fetch file C:\\Windows: The path at 'C:\\Windows' is " \
+        assert (
+            str(err.value) == "Failed to fetch file C:\\Windows: The path at 'C:\\Windows' is "
             "a directory, src must be a file"
+        )
 
-    @pytest.mark.parametrize('wsman_conn',
-                             [[True, 'test_client_fetch_file_fail_missing']],
-                             indirect=True)
+    @pytest.mark.parametrize("wsman_conn", [[True, "test_client_fetch_file_fail_missing"]], indirect=True)
     def test_client_fetch_file_fail_missing(self, wsman_conn):
         client = self._get_client(wsman_conn)
         with pytest.raises(WinRMError) as err:
             client.fetch("C:\\fakefile.txt", "")
-        assert str(err.value) == \
-            "Failed to fetch file C:\\fakefile.txt: The path at " \
-            "'C:\\fakefile.txt' does not exist"
+        assert str(err.value) == "Failed to fetch file C:\\fakefile.txt: The path at 'C:\\fakefile.txt' does not exist"
 
-    @pytest.mark.parametrize('wsman_conn',
-                             # use existing responses so I don't need to create
-                             # the file
-                             [[False, 'test_client_fetch_file_hash_mismatch']],
-                             indirect=True)
-    def test_client_fetch_file_hash_mismatch(self, wsman_conn,
-                                             monkeypatch):
+    @pytest.mark.parametrize(
+        "wsman_conn",
+        # use existing responses so I don't need to create
+        # the file
+        [[False, "test_client_fetch_file_hash_mismatch"]],
+        indirect=True,
+    )
+    def test_client_fetch_file_hash_mismatch(self, wsman_conn, monkeypatch, mocker):
         # set to a hash that is not the actual to verify the script will
         # fail in a hash mismatch scenario
-        mock_hash = MagicMock()
-        mock_hash.return_value.hexdigest.return_value = \
-            "c3499c2729730a7f807efb8676a92dcb6f8a3f8f"
+        mock_hash = mocker.MagicMock()
+        mock_hash.return_value.hexdigest.return_value = "c3499c2729730a7f807efb8676a92dcb6f8a3f8f"
         monkeypatch.setattr(hashlib, "sha1", mock_hash)
 
         # file was created with
@@ -349,15 +334,19 @@ class TestClient(object):
         client = self._get_client(wsman_conn)
         with pytest.raises(WinRMError) as err:
             client.fetch("C:\\temp\\file.txt", "")
-        assert str(err.value) == \
-            "Failed to fetch file C:\\temp\\file.txt, hash mismatch\n" \
-            "Source: eec729d9a0fa275513bc44a4cb8d4ee973b81e1a\n" \
+        assert (
+            str(err.value) == "Failed to fetch file C:\\temp\\file.txt, hash mismatch\n"
+            "Source: eec729d9a0fa275513bc44a4cb8d4ee973b81e1a\n"
             "Fetched: c3499c2729730a7f807efb8676a92dcb6f8a3f8f"
+        )
 
-    @pytest.mark.parametrize('wsman_conn',
-                             # means we don't need to create files on the
-                             # remote side
-                             [[False, 'test_client_fetch_file_expand_vars']], indirect=True)
+    @pytest.mark.parametrize(
+        "wsman_conn",
+        # means we don't need to create files on the
+        # remote side
+        [[False, "test_client_fetch_file_expand_vars"]],
+        indirect=True,
+    )
     def test_client_fetch_file_expand_vars(self, wsman_conn):
         client = self._get_client(wsman_conn)
 
@@ -369,9 +358,7 @@ class TestClient(object):
         os.remove(path)
         try:
             client.fetch("%TEMP%\\file.txt", path, expand_variables=True)
-            expected_hash = b"\x22\xC1\xA7\x8E\xC5\xAD\xA1\xCD" \
-                            b"\x2F\x36\x65\xB5\x8B\x30\x49\x9E" \
-                            b"\x51\xA3\xB0\x29"
+            expected_hash = b"\x22\xC1\xA7\x8E\xC5\xAD\xA1\xCD\x2F\x36\x65\xB5\x8B\x30\x49\x9E\x51\xA3\xB0\x29"
 
             hash = hashlib.sha1()
             with open(path, "rb") as temp_file:
@@ -387,25 +374,27 @@ class TestClient(object):
                 os.remove(path)
 
     def test_sanitise_clixml_with_error(self):
-        clixml_path = os.path.join(os.path.dirname(__file__), 'data', 'test_sanitise_clixml_with_error.xml')
-        with open(clixml_path, 'r') as fd:
+        clixml_path = os.path.join(os.path.dirname(__file__), "data", "test_sanitise_clixml_with_error.xml")
+        with open(clixml_path, "r") as fd:
             clixml = fd.read()
 
-        expected = "fake : The term 'fake' is not recognized as the name of a cmdlet, function, script file, or operable program. Check \r\n" \
-                   "the spelling of the name, or if a path was included, verify that the path is correct and try again.\r\n" \
-                   "At line:1 char:1\r\n" \
-                   "+ fake cmdlet\r\n" \
-                   "+ ~~~~\r\n" \
-                   "    + CategoryInfo          : ObjectNotFound: (fake:String) [], CommandNotFoundException\r\n" \
-                   "    + FullyQualifiedErrorId : CommandNotFoundException\r\n" \
-                   " \r\n"
+        expected = (
+            "fake : The term 'fake' is not recognized as the name of a cmdlet, function, script file, or operable program. Check \r\n"
+            "the spelling of the name, or if a path was included, verify that the path is correct and try again.\r\n"
+            "At line:1 char:1\r\n"
+            "+ fake cmdlet\r\n"
+            "+ ~~~~\r\n"
+            "    + CategoryInfo          : ObjectNotFound: (fake:String) [], CommandNotFoundException\r\n"
+            "    + FullyQualifiedErrorId : CommandNotFoundException\r\n"
+            " \r\n"
+        )
 
         actual = Client.sanitise_clixml(clixml)
         assert actual == expected
 
     def test_sanitise_clixml_with_no_errors(self):
-        clixml_path = os.path.join(os.path.dirname(__file__), 'data', 'test_sanitise_clixml_with_no_errors.xml')
-        with open(clixml_path, 'r') as fd:
+        clixml_path = os.path.join(os.path.dirname(__file__), "data", "test_sanitise_clixml_with_no_errors.xml")
+        with open(clixml_path, "r") as fd:
             clixml = fd.read()
 
         expected = ""

--- a/tests/test_complex_objects.py
+++ b/tests/test_complex_objects.py
@@ -2,15 +2,28 @@ import xml.etree.ElementTree as ET
 
 import pytest
 
-from . import assert_xml_diff
-
-from pypsrp.complex_objects import Array, BufferCell, BufferCellType, Color, \
-    Command, CommandParameter, CommandType, Coordinates, HostInfo, \
-    ObjectMeta, Pipeline, PipelineResultTypes, PSThreadOptions, \
-    RemoteStreamOptions, Size
+from pypsrp._utils import to_unicode
+from pypsrp.complex_objects import (
+    Array,
+    BufferCell,
+    BufferCellType,
+    Color,
+    Command,
+    CommandParameter,
+    CommandType,
+    Coordinates,
+    HostInfo,
+    ObjectMeta,
+    Pipeline,
+    PipelineResultTypes,
+    PSThreadOptions,
+    RemoteStreamOptions,
+    Size,
+)
 from pypsrp.host import PSHost, PSHostRawUserInterface, PSHostUserInterface
 from pypsrp.serializer import Serializer
-from pypsrp._utils import to_unicode
+
+from . import assert_xml_diff
 
 
 def normalise_xml(xml_string):
@@ -20,20 +33,20 @@ def normalise_xml(xml_string):
 
 
 class TestEnum(object):
-
     def test_enum_invalid_value(self):
         state = PSThreadOptions(value=PSThreadOptions.DEFAULT)
         assert str(state) == "Default"
         state.value = 15
         with pytest.raises(KeyError) as err:
             str(state)
-        assert "15 is not a valid enum value for System.Management." \
-               "Automation.Runspaces.PSThreadOptions" in str(err.value)
+        assert "15 is not a valid enum value for System.Management.Automation.Runspaces.PSThreadOptions" in str(
+            err.value
+        )
 
 
 class TestHostInfo(object):
 
-    HOST_XML = '''<Obj RefId="0">
+    HOST_XML = """<Obj RefId="0">
             <MS>
                 <Obj N="_hostDefaultData" RefId="1">
                     <MS>
@@ -172,7 +185,7 @@ class TestHostInfo(object):
                 <B N="_isHostRawUINull">false</B>
                 <B N="_useRunspaceHost">false</B>
             </MS>
-        </Obj>'''
+        </Obj>"""
 
     def test_create_host_info(self):
         serializer = Serializer()
@@ -189,9 +202,16 @@ class TestHostInfo(object):
         window_title = "Random Window Title"
 
         ps_raw_ui = PSHostRawUserInterface(
-            window_title, cursor_size, foreground_color, background_color,
-            cursor_position, window_position, buffer_size,
-            max_physical_window_size, max_window_size, window_size
+            window_title,
+            cursor_size,
+            foreground_color,
+            background_color,
+            cursor_position,
+            window_position,
+            buffer_size,
+            max_physical_window_size,
+            max_window_size,
+            window_size,
         )
         ps_ui = PSHostUserInterface(raw_ui=ps_raw_ui)
         ps_host = PSHost(None, None, False, None, None, ps_ui, None)
@@ -205,7 +225,6 @@ class TestHostInfo(object):
 
 
 class TestRemoteStreamOptions(object):
-
     def test_to_string_one_value(self):
         options = RemoteStreamOptions(value=1)
         expected = "AddInvocationInfoToErrorRecord"
@@ -214,15 +233,14 @@ class TestRemoteStreamOptions(object):
 
     def test_to_string_multiple_values(self):
         options = RemoteStreamOptions(value=3)
-        expected = \
-            "AddInvocationInfoToErrorRecord, AddInvocationInfoToWarningRecord"
+        expected = "AddInvocationInfoToErrorRecord, AddInvocationInfoToWarningRecord"
         actual = str(options)
         assert actual == expected
 
 
 class TestPipeline(object):
 
-    PIPE_SINGLE = '''<Obj RefId="0">
+    PIPE_SINGLE = """<Obj RefId="0">
         <MS>
             <B N="IsNested">false</B>
             <Nil N="ExtraCmds"/>
@@ -301,9 +319,9 @@ class TestPipeline(object):
             <Nil N="History"/>
             <B N="RedirectShellErrorOutputPipe">false</B>
         </MS>
-    </Obj>'''
+    </Obj>"""
 
-    PIPE_MULTIPLE = '''<Obj RefId="0">
+    PIPE_MULTIPLE = """<Obj RefId="0">
         <MS>
             <B N="IsNested">false</B>
             <Obj N="ExtraCmds" RefId="1">
@@ -562,7 +580,7 @@ class TestPipeline(object):
             <Nil N="History"/>
             <B N="RedirectShellErrorOutputPipe">false</B>
         </MS>
-    </Obj>'''
+    </Obj>"""
 
     def test_create_pipeline_single(self):
         serializer = Serializer()
@@ -571,11 +589,8 @@ class TestPipeline(object):
         command.cmd = "Set-Variable"
         command.is_script = False
         command.use_local_scope = False
-        command.args = [
-            CommandParameter(name="Name", value="var"),
-            CommandParameter(name="Value", value="abc")
-        ]
-        assert str(command) == 'None'
+        command.args = [CommandParameter(name="Name", value="var"), CommandParameter(name="Value", value="abc")]
+        assert str(command) == "None"
 
         pipeline = Pipeline()
         pipeline.is_nested = False
@@ -596,11 +611,8 @@ class TestPipeline(object):
         command1.is_script = False
         command1.use_local_scope = False
         command1.end_of_statement = True
-        command1.args = [
-            CommandParameter(name="Name", value="var"),
-            CommandParameter(name="Value", value="abc")
-        ]
-        assert str(command1) == 'None'
+        command1.args = [CommandParameter(name="Name", value="var"), CommandParameter(name="Value", value="abc")]
+        assert str(command1) == "None"
 
         command2 = Command(protocol_version="2.2")
         command2.cmd = "Get-Variable"
@@ -609,13 +621,13 @@ class TestPipeline(object):
         command2.args = [
             CommandParameter(name="Name", value="var"),
         ]
-        assert str(command2) == 'None'
+        assert str(command2) == "None"
 
         command3 = Command(protocol_version="2.2")
         command3.cmd = "Write-Output"
         command3.is_script = False
         command3.use_local_scope = False
-        assert str(command3) == 'None'
+        assert str(command3) == "None"
 
         pipeline = Pipeline()
         pipeline.is_nested = False
@@ -630,8 +642,7 @@ class TestPipeline(object):
 
     def test_parse_pipeline_single(self):
         serializer = Serializer()
-        actual = serializer.deserialize(normalise_xml(self.PIPE_SINGLE),
-                                        ObjectMeta("Obj", object=Pipeline))
+        actual = serializer.deserialize(normalise_xml(self.PIPE_SINGLE), ObjectMeta("Obj", object=Pipeline))
         assert actual.history is None
         assert actual.is_nested is False
         assert actual.redirect_err_to_out is False
@@ -654,8 +665,7 @@ class TestPipeline(object):
 
     def test_parse_pipeline_multiple(self):
         serializer = Serializer()
-        actual = serializer.deserialize(normalise_xml(self.PIPE_MULTIPLE),
-                                        ObjectMeta("Obj", object=Pipeline))
+        actual = serializer.deserialize(normalise_xml(self.PIPE_MULTIPLE), ObjectMeta("Obj", object=Pipeline))
         assert actual.history is None
         assert actual.is_nested is False
         assert actual.redirect_err_to_out is False
@@ -704,7 +714,6 @@ class TestPipeline(object):
 
 
 class TestCommandType(object):
-
     def test_to_string_one_value(self):
         command_type = CommandType(value=1)
         expected = "Alias"
@@ -725,7 +734,6 @@ class TestCommandType(object):
 
 
 class TestPipelineResultTypes(object):
-
     def test_to_string_one_value(self):
         result_type = PipelineResultTypes(value=1)
         expected = "Output"
@@ -765,7 +773,7 @@ class TestPipelineResultTypes(object):
 
 class TestBufferCell(object):
 
-    BUFFER_CELL = '''<Obj RefId="0">
+    BUFFER_CELL = """<Obj RefId="0">
     <Props>
         <C N="character">65</C>
         <Obj N="foregroundColor" RefId="1">
@@ -785,15 +793,16 @@ class TestBufferCell(object):
         </Obj>
         <I32 N="bufferCellType">0</I32>
     </Props>
-</Obj>'''
+</Obj>"""
 
     def test_create_buffer_cell(self):
         serializer = Serializer()
 
         buffer_cell = BufferCell(
-            character="A", foreground_color=Color(value=Color.CYAN),
+            character="A",
+            foreground_color=Color(value=Color.CYAN),
             background_color=Color(value=Color.GREEN),
-            cell_type=BufferCellType.COMPLETE
+            cell_type=BufferCellType.COMPLETE,
         )
 
         expected_xml = normalise_xml(self.BUFFER_CELL)
@@ -804,8 +813,7 @@ class TestBufferCell(object):
 
     def test_parse_buffer_cell(self):
         serializer = Serializer()
-        actual = serializer.deserialize(normalise_xml(self.BUFFER_CELL),
-                                        ObjectMeta("Obj", object=BufferCell))
+        actual = serializer.deserialize(normalise_xml(self.BUFFER_CELL), ObjectMeta("Obj", object=BufferCell))
 
         assert actual.character == "A"
         assert actual.foreground_color.value == Color.CYAN
@@ -815,7 +823,7 @@ class TestBufferCell(object):
 
 class TestArray(object):
 
-    SINGLE_ARRAY = '''<Obj RefId="0">
+    SINGLE_ARRAY = """<Obj RefId="0">
     <MS>
         <Obj N="mae" RefId="1">
             <TN RefId="0">
@@ -836,9 +844,9 @@ class TestArray(object):
             </LST>
         </Obj>
     </MS>
-</Obj>'''
+</Obj>"""
 
-    SINGLE_ARRAY2 = '''<Obj RefId="0">
+    SINGLE_ARRAY2 = """<Obj RefId="0">
         <MS>
             <Obj N="mae" RefId="1">
                 <TN RefId="0">
@@ -859,9 +867,9 @@ class TestArray(object):
                 </LST>
             </Obj>
         </MS>
-    </Obj>'''
+    </Obj>"""
 
-    TWO_ARRAY = '''<Obj RefId="0">
+    TWO_ARRAY = """<Obj RefId="0">
     <MS>
         <Obj N="mae" RefId="1">
             <TN RefId="0">
@@ -889,9 +897,9 @@ class TestArray(object):
             </LST>
         </Obj>
     </MS>
-</Obj>'''
+</Obj>"""
 
-    THREE_ARRAY = '''<Obj RefId="0">
+    THREE_ARRAY = """<Obj RefId="0">
     <MS>
         <Obj N="mae" RefId="1">
             <TN RefId="0">
@@ -935,7 +943,7 @@ class TestArray(object):
             </LST>
         </Obj>
     </MS>
-</Obj>'''
+</Obj>"""
 
     def test_create_array(self):
         serializer = Serializer()
@@ -957,8 +965,7 @@ class TestArray(object):
 
     def test_parse_array(self):
         serializer = Serializer()
-        actual = serializer.deserialize(self.SINGLE_ARRAY,
-                                        ObjectMeta("Obj", object=Array))
+        actual = serializer.deserialize(self.SINGLE_ARRAY, ObjectMeta("Obj", object=Array))
         array = actual.array
         assert array == [1, 2, 3]
         assert actual.mae == [1, 2, 3]
@@ -977,8 +984,7 @@ class TestArray(object):
 
     def test_parse_two_dimensional_array(self):
         serializer = Serializer()
-        actual = serializer.deserialize(self.TWO_ARRAY,
-                                        ObjectMeta("Obj", object=Array))
+        actual = serializer.deserialize(self.TWO_ARRAY, ObjectMeta("Obj", object=Array))
         array = actual.array
         assert array == [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
         assert actual.mae == [1, 2, 3, 4, 5, 6, 7, 8, 9]
@@ -987,10 +993,12 @@ class TestArray(object):
     def test_three_dimensional_create_array(self):
         serializer = Serializer()
 
-        array = Array(array=[
-            [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]],
-            [[13, 14, 15, 16], [17, 18, 19, 20], [21, 22, 23, 24]]
-        ])
+        array = Array(
+            array=[
+                [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]],
+                [[13, 14, 15, 16], [17, 18, 19, 20], [21, 22, 23, 24]],
+            ]
+        )
 
         expected_xml = normalise_xml(self.THREE_ARRAY)
         actual = serializer.serialize(array)
@@ -1000,13 +1008,11 @@ class TestArray(object):
 
     def test_parse_three_dimensional_array(self):
         serializer = Serializer()
-        actual = serializer.deserialize(self.THREE_ARRAY,
-                                        ObjectMeta("Obj", object=Array))
+        actual = serializer.deserialize(self.THREE_ARRAY, ObjectMeta("Obj", object=Array))
         array = actual.array
         assert array == [
             [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]],
-            [[13, 14, 15, 16], [17, 18, 19, 20], [21, 22, 23, 24]]
+            [[13, 14, 15, 16], [17, 18, 19, 20], [21, 22, 23, 24]],
         ]
-        assert actual.mae == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
-                              13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24]
+        assert actual.mae == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24]
         assert actual.mal == [2, 3, 4]

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -1,31 +1,30 @@
 import collections
+
 import pytest
 
 from pypsrp.encryption import WinRMEncryption
 from pypsrp.exceptions import WinRMError
 
-
-WrapIOVResult = collections.namedtuple('WrapIOVResult', ['buffers'])
-WrapResult = collections.namedtuple('WrapResult', ['data'])
+WrapIOVResult = collections.namedtuple("WrapIOVResult", ["buffers"])
+WrapResult = collections.namedtuple("WrapResult", ["data"])
 
 
 class MockAuthCREDSSP(object):
-
     def __init__(self):
         class TlsConnection(object):
             def get_cipher_name(self):
                 return "ECDHE-RSA-AES256-GCM-SHA384"
+
         self.tls_connection = TlsConnection()
 
     def wrap(self, data):
         return data + b"-encrypted"
 
     def unwrap(self, data):
-        return data[:len(data) - 10]
+        return data[: len(data) - 10]
 
 
 class MockAuthSPNEGO(object):
-
     def __init__(self, padding=False):
         self.padding = padding
 
@@ -33,20 +32,21 @@ class MockAuthSPNEGO(object):
         return b"reallylongheader", data + b"-encrypted", 1 if self.padding else 0
 
     def unwrap_winrm(self, header, data):
-        return data[:len(data) - 10]
+        return data[: len(data) - 10]
 
 
 class TestWinRMEncryption(object):
-
     def test_wrap_small_spnego(self):
         plaintext = b"plaintext"
         encryption = WinRMEncryption(MockAuthSPNEGO(), WinRMEncryption.SPNEGO)
-        expected = b"--Encrypted Boundary\r\n\tContent-Type: application" \
-                   b"/HTTP-SPNEGO-session-encrypted\r\n\tOriginalContent: " \
-                   b"type=application/soap+xml;charset=UTF-8;Length=9\r\n" \
-                   b"--Encrypted Boundary\r\n\tContent-Type: application/" \
-                   b"octet-stream\r\n\x10\x00\x00\x00reallylongheaderplaintext-" \
-                   b"encrypted--Encrypted Boundary--\r\n"
+        expected = (
+            b"--Encrypted Boundary\r\n\tContent-Type: application"
+            b"/HTTP-SPNEGO-session-encrypted\r\n\tOriginalContent: "
+            b"type=application/soap+xml;charset=UTF-8;Length=9\r\n"
+            b"--Encrypted Boundary\r\n\tContent-Type: application/"
+            b"octet-stream\r\n\x10\x00\x00\x00reallylongheaderplaintext-"
+            b"encrypted--Encrypted Boundary--\r\n"
+        )
         actual_type, actual = encryption.wrap_message(plaintext)
 
         assert "multipart/encrypted" == actual_type
@@ -55,12 +55,14 @@ class TestWinRMEncryption(object):
     def test_wrap_spnego_padded(self):
         plaintext = b"plaintext"
         encryption = WinRMEncryption(MockAuthSPNEGO(padding=True), WinRMEncryption.SPNEGO)
-        expected = b"--Encrypted Boundary\r\n\tContent-Type: application" \
-                   b"/HTTP-SPNEGO-session-encrypted\r\n\tOriginalContent: " \
-                   b"type=application/soap+xml;charset=UTF-8;Length=10\r\n" \
-                   b"--Encrypted Boundary\r\n\tContent-Type: application/" \
-                   b"octet-stream\r\n\x10\x00\x00\x00reallylongheaderplaintext-" \
-                   b"encrypted--Encrypted Boundary--\r\n"
+        expected = (
+            b"--Encrypted Boundary\r\n\tContent-Type: application"
+            b"/HTTP-SPNEGO-session-encrypted\r\n\tOriginalContent: "
+            b"type=application/soap+xml;charset=UTF-8;Length=10\r\n"
+            b"--Encrypted Boundary\r\n\tContent-Type: application/"
+            b"octet-stream\r\n\x10\x00\x00\x00reallylongheaderplaintext-"
+            b"encrypted--Encrypted Boundary--\r\n"
+        )
         actual_type, actual = encryption.wrap_message(plaintext)
 
         assert "multipart/encrypted" == actual_type
@@ -69,12 +71,14 @@ class TestWinRMEncryption(object):
     def test_wrap_small_kerberos(self):
         plaintext = b"plaintext"
         encryption = WinRMEncryption(MockAuthSPNEGO(), WinRMEncryption.KERBEROS)
-        expected = b"--Encrypted Boundary\r\n\tContent-Type: application" \
-                   b"/HTTP-Kerberos-session-encrypted\r\n\tOriginalContent: " \
-                   b"type=application/soap+xml;charset=UTF-8;Length=9\r\n" \
-                   b"--Encrypted Boundary\r\n\tContent-Type: application/" \
-                   b"octet-stream\r\n\x10\x00\x00\x00reallylongheaderplaintext-" \
-                   b"encrypted--Encrypted Boundary--\r\n"
+        expected = (
+            b"--Encrypted Boundary\r\n\tContent-Type: application"
+            b"/HTTP-Kerberos-session-encrypted\r\n\tOriginalContent: "
+            b"type=application/soap+xml;charset=UTF-8;Length=9\r\n"
+            b"--Encrypted Boundary\r\n\tContent-Type: application/"
+            b"octet-stream\r\n\x10\x00\x00\x00reallylongheaderplaintext-"
+            b"encrypted--Encrypted Boundary--\r\n"
+        )
         actual_type, actual = encryption.wrap_message(plaintext)
 
         assert "multipart/encrypted" == actual_type
@@ -83,12 +87,14 @@ class TestWinRMEncryption(object):
     def test_wrap_small_credsp(self):
         plaintext = b"plaintext"
         encryption = WinRMEncryption(MockAuthCREDSSP(), WinRMEncryption.CREDSSP)
-        expected = b"--Encrypted Boundary\r\n\tContent-Type: application" \
-                   b"/HTTP-CredSSP-session-encrypted\r\n\tOriginalContent: " \
-                   b"type=application/soap+xml;charset=UTF-8;Length=9\r\n" \
-                   b"--Encrypted Boundary\r\n\tContent-Type: application/" \
-                   b"octet-stream\r\n\x10\x00\x00\x00plaintext-encrypted" \
-                   b"--Encrypted Boundary--\r\n"
+        expected = (
+            b"--Encrypted Boundary\r\n\tContent-Type: application"
+            b"/HTTP-CredSSP-session-encrypted\r\n\tOriginalContent: "
+            b"type=application/soap+xml;charset=UTF-8;Length=9\r\n"
+            b"--Encrypted Boundary\r\n\tContent-Type: application/"
+            b"octet-stream\r\n\x10\x00\x00\x00plaintext-encrypted"
+            b"--Encrypted Boundary--\r\n"
+        )
         actual_type, actual = encryption.wrap_message(plaintext)
 
         assert "multipart/encrypted" == actual_type
@@ -97,12 +103,13 @@ class TestWinRMEncryption(object):
     def test_wrap_large_spnego(self):
         plaintext = b"a" * 20000
         encryption = WinRMEncryption(MockAuthSPNEGO(), WinRMEncryption.SPNEGO)
-        expected = b"--Encrypted Boundary\r\n\tContent-Type: application" \
-                   b"/HTTP-SPNEGO-session-encrypted\r\n\tOriginalContent: " \
-                   b"type=application/soap+xml;charset=UTF-8;Length=20000" \
-                   b"\r\n--Encrypted Boundary\r\n\tContent-Type: application" \
-                   b"/octet-stream\r\n\x10\x00\x00\x00reallylongheader" + plaintext + \
-                   b"-encrypted--Encrypted Boundary--\r\n"
+        expected = (
+            b"--Encrypted Boundary\r\n\tContent-Type: application"
+            b"/HTTP-SPNEGO-session-encrypted\r\n\tOriginalContent: "
+            b"type=application/soap+xml;charset=UTF-8;Length=20000"
+            b"\r\n--Encrypted Boundary\r\n\tContent-Type: application"
+            b"/octet-stream\r\n\x10\x00\x00\x00reallylongheader" + plaintext + b"-encrypted--Encrypted Boundary--\r\n"
+        )
         actual_type, actual = encryption.wrap_message(plaintext)
 
         assert "multipart/encrypted" == actual_type
@@ -111,12 +118,13 @@ class TestWinRMEncryption(object):
     def test_wrap_large_kerberos(self):
         plaintext = b"a" * 20000
         encryption = WinRMEncryption(MockAuthSPNEGO(), WinRMEncryption.KERBEROS)
-        expected = b"--Encrypted Boundary\r\n\tContent-Type: application" \
-                   b"/HTTP-Kerberos-session-encrypted\r\n\tOriginalContent: " \
-                   b"type=application/soap+xml;charset=UTF-8;Length=20000" \
-                   b"\r\n--Encrypted Boundary\r\n\tContent-Type: application" \
-                   b"/octet-stream\r\n\x10\x00\x00\x00reallylongheader" + plaintext + \
-                   b"-encrypted--Encrypted Boundary--\r\n"
+        expected = (
+            b"--Encrypted Boundary\r\n\tContent-Type: application"
+            b"/HTTP-Kerberos-session-encrypted\r\n\tOriginalContent: "
+            b"type=application/soap+xml;charset=UTF-8;Length=20000"
+            b"\r\n--Encrypted Boundary\r\n\tContent-Type: application"
+            b"/octet-stream\r\n\x10\x00\x00\x00reallylongheader" + plaintext + b"-encrypted--Encrypted Boundary--\r\n"
+        )
         actual_type, actual = encryption.wrap_message(plaintext)
 
         assert "multipart/encrypted" == actual_type
@@ -125,18 +133,18 @@ class TestWinRMEncryption(object):
     def test_wrap_large_credsp(self):
         plaintext = b"a" * 20000
         encryption = WinRMEncryption(MockAuthCREDSSP(), WinRMEncryption.CREDSSP)
-        expected = b"--Encrypted Boundary\r\n\tContent-Type: application" \
-                   b"/HTTP-CredSSP-session-encrypted\r\n\tOriginalContent: " \
-                   b"type=application/soap+xml;charset=UTF-8;Length=16384" \
-                   b"\r\n--Encrypted Boundary\r\n\tContent-Type: application" \
-                   b"/octet-stream\r\n\x10\x00\x00\x00" + b"a" * 16384 + \
-                   b"-encrypted--Encrypted Boundary\r\n\tContent-Type: " \
-                   b"application/HTTP-CredSSP-session-encrypted\r\n" \
-                   b"\tOriginalContent: type=application/soap+xml;" \
-                   b"charset=UTF-8;Length=3616\r\n--Encrypted Boundary\r\n" \
-                   b"\tContent-Type: application/octet-stream\r\n" \
-                   b"\x10\x00\x00\x00" + b"a" * 3616 + \
-                   b"-encrypted--Encrypted Boundary--\r\n"
+        expected = (
+            b"--Encrypted Boundary\r\n\tContent-Type: application"
+            b"/HTTP-CredSSP-session-encrypted\r\n\tOriginalContent: "
+            b"type=application/soap+xml;charset=UTF-8;Length=16384"
+            b"\r\n--Encrypted Boundary\r\n\tContent-Type: application"
+            b"/octet-stream\r\n\x10\x00\x00\x00" + b"a" * 16384 + b"-encrypted--Encrypted Boundary\r\n\tContent-Type: "
+            b"application/HTTP-CredSSP-session-encrypted\r\n"
+            b"\tOriginalContent: type=application/soap+xml;"
+            b"charset=UTF-8;Length=3616\r\n--Encrypted Boundary\r\n"
+            b"\tContent-Type: application/octet-stream\r\n"
+            b"\x10\x00\x00\x00" + b"a" * 3616 + b"-encrypted--Encrypted Boundary--\r\n"
+        )
         actual_type, actual = encryption.wrap_message(plaintext)
 
         assert "multipart/x-multi-encrypted" == actual_type
@@ -145,24 +153,28 @@ class TestWinRMEncryption(object):
     def test_unwrap_small_spnego(self):
         expected = b"plaintext"
         encryption = WinRMEncryption(MockAuthSPNEGO(), WinRMEncryption.SPNEGO)
-        bwrapped = b"--Encrypted Boundary\r\n\tContent-Type: application" \
-                   b"/HTTP-SPNEGO-session-encrypted\r\n\tOriginalContent: " \
-                   b"type=application/soap+xml;charset=UTF-8;Length=9\r\n" \
-                   b"--Encrypted Boundary\r\n\tContent-Type: application/" \
-                   b"octet-stream\r\n\x10\x00\x00\x00reallylongheaderplaintext-" \
-                   b"encrypted--Encrypted Boundary--\r\n"
+        bwrapped = (
+            b"--Encrypted Boundary\r\n\tContent-Type: application"
+            b"/HTTP-SPNEGO-session-encrypted\r\n\tOriginalContent: "
+            b"type=application/soap+xml;charset=UTF-8;Length=9\r\n"
+            b"--Encrypted Boundary\r\n\tContent-Type: application/"
+            b"octet-stream\r\n\x10\x00\x00\x00reallylongheaderplaintext-"
+            b"encrypted--Encrypted Boundary--\r\n"
+        )
         actual = encryption.unwrap_message(bwrapped, "Encrypted Boundary")
         assert expected == actual
 
     def test_unwrap_small_spnego_without_end_hyphens(self):
         expected = b"plaintext"
         encryption = WinRMEncryption(MockAuthSPNEGO(), WinRMEncryption.SPNEGO)
-        bwrapped = b"--Encrypted Boundary\r\n\tContent-Type: application" \
-                   b"/HTTP-SPNEGO-session-encrypted\r\n\tOriginalContent: " \
-                   b"type=application/soap+xml;charset=UTF-8;Length=9\r\n" \
-                   b"--Encrypted Boundary\r\n\tContent-Type: application/" \
-                   b"octet-stream\r\n\x10\x00\x00\x00reallylongheaderplaintext-" \
-                   b"encrypted--Encrypted Boundary\r\n"
+        bwrapped = (
+            b"--Encrypted Boundary\r\n\tContent-Type: application"
+            b"/HTTP-SPNEGO-session-encrypted\r\n\tOriginalContent: "
+            b"type=application/soap+xml;charset=UTF-8;Length=9\r\n"
+            b"--Encrypted Boundary\r\n\tContent-Type: application/"
+            b"octet-stream\r\n\x10\x00\x00\x00reallylongheaderplaintext-"
+            b"encrypted--Encrypted Boundary\r\n"
+        )
         actual = encryption.unwrap_message(bwrapped, "Encrypted Boundary")
         assert expected == actual
 
@@ -171,24 +183,28 @@ class TestWinRMEncryption(object):
         encryption = WinRMEncryption(MockAuthSPNEGO(), WinRMEncryption.KERBEROS)
 
         # The spaces after -- on each boundary is on purpose, some MS implementations do this.
-        bwrapped = b"-- Encrypted Boundary\r\n\tContent-Type: application" \
-                   b"/HTTP-Kerberos-session-encrypted\r\n\tOriginalContent: " \
-                   b"type=application/soap+xml;charset=UTF-8;Length=9\r\n" \
-                   b"-- Encrypted Boundary\r\n\tContent-Type: application/" \
-                   b"octet-stream\r\n\x10\x00\x00\x00reallylongheaderplaintext-" \
-                   b"encrypted-- Encrypted Boundary--\r\n"
+        bwrapped = (
+            b"-- Encrypted Boundary\r\n\tContent-Type: application"
+            b"/HTTP-Kerberos-session-encrypted\r\n\tOriginalContent: "
+            b"type=application/soap+xml;charset=UTF-8;Length=9\r\n"
+            b"-- Encrypted Boundary\r\n\tContent-Type: application/"
+            b"octet-stream\r\n\x10\x00\x00\x00reallylongheaderplaintext-"
+            b"encrypted-- Encrypted Boundary--\r\n"
+        )
         actual = encryption.unwrap_message(bwrapped, "Encrypted Boundary")
         assert expected == actual
 
     def test_unwrap_small_credsp(self):
         expected = b"plaintext"
         encryption = WinRMEncryption(MockAuthCREDSSP(), WinRMEncryption.CREDSSP)
-        bwrapped = b"--Encrypted Boundary2\r\n\tContent-Type: application" \
-                   b"/HTTP-CredSSP-session-encrypted\r\n\tOriginalContent: " \
-                   b"type=application/soap+xml;charset=UTF-8;Length=9\r\n" \
-                   b"--Encrypted Boundary2\r\n\tContent-Type: application/" \
-                   b"octet-stream\r\n\x10\x00\x00\x00plaintext-encrypted" \
-                   b"--Encrypted Boundary2--\r\n"
+        bwrapped = (
+            b"--Encrypted Boundary2\r\n\tContent-Type: application"
+            b"/HTTP-CredSSP-session-encrypted\r\n\tOriginalContent: "
+            b"type=application/soap+xml;charset=UTF-8;Length=9\r\n"
+            b"--Encrypted Boundary2\r\n\tContent-Type: application/"
+            b"octet-stream\r\n\x10\x00\x00\x00plaintext-encrypted"
+            b"--Encrypted Boundary2--\r\n"
+        )
         actual = encryption.unwrap_message(bwrapped, "Encrypted Boundary2")
 
         assert expected == actual
@@ -196,12 +212,13 @@ class TestWinRMEncryption(object):
     def test_unwrap_large_spnego(self):
         expected = b"a" * 20000
         encryption = WinRMEncryption(MockAuthSPNEGO(), WinRMEncryption.SPNEGO)
-        bwrapped = b"--Encrypted Boundary\r\n\tContent-Type: application" \
-                   b"/HTTP-SPNEGO-session-encrypted\r\n\tOriginalContent: " \
-                   b"type=application/soap+xml;charset=UTF-8;Length=20000" \
-                   b"\r\n--Encrypted Boundary\r\n\tContent-Type: application" \
-                   b"/octet-stream\r\n\x10\x00\x00\x00reallylongheader" + expected + \
-                   b"-encrypted--Encrypted Boundary--\r\n"
+        bwrapped = (
+            b"--Encrypted Boundary\r\n\tContent-Type: application"
+            b"/HTTP-SPNEGO-session-encrypted\r\n\tOriginalContent: "
+            b"type=application/soap+xml;charset=UTF-8;Length=20000"
+            b"\r\n--Encrypted Boundary\r\n\tContent-Type: application"
+            b"/octet-stream\r\n\x10\x00\x00\x00reallylongheader" + expected + b"-encrypted--Encrypted Boundary--\r\n"
+        )
         actual = encryption.unwrap_message(bwrapped, "Encrypted Boundary")
 
         assert expected == actual
@@ -209,12 +226,13 @@ class TestWinRMEncryption(object):
     def test_unwrap_large_kerberos(self):
         expected = b"a" * 20000
         encryption = WinRMEncryption(MockAuthSPNEGO(), WinRMEncryption.KERBEROS)
-        bwrapped = b"--Encrypted Boundary\r\n\tContent-Type: application" \
-                   b"/HTTP-Kerberos-session-encrypted\r\n\tOriginalContent: " \
-                   b"type=application/soap+xml;charset=UTF-8;Length=20000" \
-                   b"\r\n--Encrypted Boundary\r\n\tContent-Type: application" \
-                   b"/octet-stream\r\n\x10\x00\x00\x00reallylongheader" + expected + \
-                   b"-encrypted--Encrypted Boundary--\r\n"
+        bwrapped = (
+            b"--Encrypted Boundary\r\n\tContent-Type: application"
+            b"/HTTP-Kerberos-session-encrypted\r\n\tOriginalContent: "
+            b"type=application/soap+xml;charset=UTF-8;Length=20000"
+            b"\r\n--Encrypted Boundary\r\n\tContent-Type: application"
+            b"/octet-stream\r\n\x10\x00\x00\x00reallylongheader" + expected + b"-encrypted--Encrypted Boundary--\r\n"
+        )
         actual = encryption.unwrap_message(bwrapped, "Encrypted Boundary")
 
         assert expected == actual
@@ -222,46 +240,51 @@ class TestWinRMEncryption(object):
     def test_unwrap_large_credsp(self):
         expected = b"a" * 20000
         encryption = WinRMEncryption(MockAuthCREDSSP(), WinRMEncryption.CREDSSP)
-        bwrapped = b"--Encrypted Boundary\r\n\tContent-Type: application" \
-                   b"/HTTP-CredSSP-session-encrypted\r\n\tOriginalContent: " \
-                   b"type=application/soap+xml;charset=UTF-8;Length=16384" \
-                   b"\r\n--Encrypted Boundary\r\n\tContent-Type: application" \
-                   b"/octet-stream\r\n\x10\x00\x00\x00" + b"a" * 16384 + \
-                   b"-encrypted--Encrypted Boundary\r\n\tContent-Type: " \
-                   b"application/HTTP-CredSSP-session-encrypted\r\n" \
-                   b"\tOriginalContent: type=application/soap+xml;" \
-                   b"charset=UTF-8;Length=3616\r\n--Encrypted Boundary\r\n" \
-                   b"\tContent-Type: application/octet-stream\r\n" \
-                   b"\x10\x00\x00\x00" + b"a" * 3616 + \
-                   b"-encrypted--Encrypted Boundary--\r\n"
+        bwrapped = (
+            b"--Encrypted Boundary\r\n\tContent-Type: application"
+            b"/HTTP-CredSSP-session-encrypted\r\n\tOriginalContent: "
+            b"type=application/soap+xml;charset=UTF-8;Length=16384"
+            b"\r\n--Encrypted Boundary\r\n\tContent-Type: application"
+            b"/octet-stream\r\n\x10\x00\x00\x00" + b"a" * 16384 + b"-encrypted--Encrypted Boundary\r\n\tContent-Type: "
+            b"application/HTTP-CredSSP-session-encrypted\r\n"
+            b"\tOriginalContent: type=application/soap+xml;"
+            b"charset=UTF-8;Length=3616\r\n--Encrypted Boundary\r\n"
+            b"\tContent-Type: application/octet-stream\r\n"
+            b"\x10\x00\x00\x00" + b"a" * 3616 + b"-encrypted--Encrypted Boundary--\r\n"
+        )
         actual = encryption.unwrap_message(bwrapped, "Encrypted Boundary")
 
         assert expected == actual
 
     def test_unwrap_length_mismatch(self):
         encryption = WinRMEncryption(MockAuthSPNEGO(), WinRMEncryption.SPNEGO)
-        bwrapped = b"--Encrypted Boundary\r\n\tContent-Type: application" \
-                   b"/HTTP-SPNEGO-session-encrypted\r\n\tOriginalContent: " \
-                   b"type=application/soap+xml;charset=UTF-8;Length=9\r\n" \
-                   b"--Encrypted Boundary\r\n\tContent-Type: application/" \
-                   b"octet-stream\r\n\x10\x00\x00\x00reallylongheaderplain-" \
-                   b"encrypted--Encrypted Boundary--\r\n"
+        bwrapped = (
+            b"--Encrypted Boundary\r\n\tContent-Type: application"
+            b"/HTTP-SPNEGO-session-encrypted\r\n\tOriginalContent: "
+            b"type=application/soap+xml;charset=UTF-8;Length=9\r\n"
+            b"--Encrypted Boundary\r\n\tContent-Type: application/"
+            b"octet-stream\r\n\x10\x00\x00\x00reallylongheaderplain-"
+            b"encrypted--Encrypted Boundary--\r\n"
+        )
 
         with pytest.raises(WinRMError) as err:
             encryption.unwrap_message(bwrapped, "Encrypted Boundary")
 
-        assert str(err.value) == \
-            "The encrypted length from the server does not match the " \
+        assert (
+            str(err.value) == "The encrypted length from the server does not match the "
             "expected length, decryption failed, actual: 5 != expected: 9"
+        )
 
-    @pytest.mark.parametrize('cipher, expected', [
-        ['ECDHE-RSA-AES128-GCM-SHA256', 16],
-        ['RC4-MD5', 16],
-        ['ECDH-ECDSA-3DES-SHA256', 34],
-        ['ECDH-RSA-AES-SHA384', 50],
-        ['ECDH-RSA-AES', 2],
-
-    ])
+    @pytest.mark.parametrize(
+        "cipher, expected",
+        [
+            ["ECDHE-RSA-AES128-GCM-SHA256", 16],
+            ["RC4-MD5", 16],
+            ["ECDH-ECDSA-3DES-SHA256", 34],
+            ["ECDH-RSA-AES-SHA384", 50],
+            ["ECDH-RSA-AES", 2],
+        ],
+    )
     def test_get_credssp_trailer_length(self, cipher, expected):
         encryption = WinRMEncryption(None, WinRMEncryption.CREDSSP)
         actual = encryption._credssp_trailer(30, cipher)

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,9 +1,16 @@
 import pytest
 
-from pypsrp.exceptions import AuthenticationError, FragmentError, \
-    InvalidPipelineStateError, InvalidPSRPOperation, \
-    InvalidRunspacePoolStateError, SerializationError, WinRMError, \
-    WinRMTransportError, WSManFaultError
+from pypsrp.exceptions import (
+    AuthenticationError,
+    FragmentError,
+    InvalidPipelineStateError,
+    InvalidPSRPOperation,
+    InvalidRunspacePoolStateError,
+    SerializationError,
+    WinRMError,
+    WinRMTransportError,
+    WSManFaultError,
+)
 
 
 def test_winrm_error():
@@ -21,8 +28,7 @@ def test_authentication_error():
 def test_winrm_transport_error():
     with pytest.raises(WinRMTransportError) as exc:
         raise WinRMTransportError("proto", 1234, "response")
-    assert str(exc.value) == "Bad PROTO response returned from the server. " \
-                             "Code: 1234, Content: 'response'"
+    assert str(exc.value) == "Bad PROTO response returned from the server. Code: 1234, Content: 'response'"
     assert exc.value.protocol == "proto"
     assert exc.value.code == 1234
     assert exc.value.response_text == "response"
@@ -30,12 +36,13 @@ def test_winrm_transport_error():
 
 def test_wsman_fault_error():
     with pytest.raises(WSManFaultError) as exc:
-        raise WSManFaultError(1234, "machine", "reason", "provider", "path",
-                              "fault")
-    assert str(exc.value) == "Received a WSManFault message. (Code: 1234, " \
-                             "Machine: machine, Reason: reason, " \
-                             "Provider: provider, Provider Path: path, " \
-                             "Provider Fault: fault)"
+        raise WSManFaultError(1234, "machine", "reason", "provider", "path", "fault")
+    assert (
+        str(exc.value) == "Received a WSManFault message. (Code: 1234, "
+        "Machine: machine, Reason: reason, "
+        "Provider: provider, Provider Path: path, "
+        "Provider Fault: fault)"
+    )
     assert exc.value.code == 1234
     assert exc.value.machine == "machine"
     assert exc.value.reason == "reason"
@@ -47,23 +54,23 @@ def test_wsman_fault_error():
 def test_wsman_fault_error_empty():
     with pytest.raises(WSManFaultError) as exc:
         raise WSManFaultError(None, None, None, None, None, None)
-    assert str(exc.value) == "Received a WSManFault message. (No details " \
-                             "returned by the server)"
+    assert str(exc.value) == "Received a WSManFault message. (No details returned by the server)"
 
 
 def test_invalid_runspace_pool_state_error():
     with pytest.raises(InvalidRunspacePoolStateError) as exc:
         raise InvalidRunspacePoolStateError(0, [1, 2], "do action")
-    assert str(exc.value) == "Cannot 'do action' on the current state " \
-                             "'BeforeOpen', expecting state(s): " \
-                             "'Opening, Opened'"
+    assert (
+        str(exc.value) == "Cannot 'do action' on the current state "
+        "'BeforeOpen', expecting state(s): "
+        "'Opening, Opened'"
+    )
 
 
 def test_invalid_pipeline_state_error():
     with pytest.raises(InvalidPipelineStateError) as exc:
         raise InvalidPipelineStateError(0, 1, "do action")
-    assert str(exc.value) == "Cannot 'do action' on the current state " \
-                             "'NotStarted', expecting state(s): 'Running'"
+    assert str(exc.value) == "Cannot 'do action' on the current state 'NotStarted', expecting state(s): 'Running'"
 
 
 def test_invalid_psrp_operation():

--- a/tests/test_host.py
+++ b/tests/test_host.py
@@ -1,22 +1,26 @@
 import uuid
 
 import pytest
-
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric import rsa
 
-from pypsrp.complex_objects import Color, ControlKeyState, Coordinates, \
-    CultureInfo, KeyInfo, KeyInfoDotNet, GenericComplexObject, \
-    HostMethodIdentifier, ObjectMeta, PSCredential, Size
+from pypsrp.complex_objects import (
+    Color,
+    ControlKeyState,
+    Coordinates,
+    CultureInfo,
+    GenericComplexObject,
+    HostMethodIdentifier,
+    KeyInfo,
+    KeyInfoDotNet,
+    ObjectMeta,
+    PSCredential,
+    Size,
+)
 from pypsrp.host import PSHost, PSHostRawUserInterface, PSHostUserInterface
 from pypsrp.messages import ProgressRecord
 from pypsrp.powershell import PowerShell, RunspacePool
 from pypsrp.wsman import WSMan
-
-try:
-    from unittest.mock import MagicMock
-except ImportError:
-    from mock import MagicMock
 
 
 def gen_rsa_keypair(public_exponent, key_size, backend):
@@ -36,19 +40,19 @@ def gen_rsa_keypair(public_exponent, key_size, backend):
     n = 24692106711502830011203227021058444318027801046612842012663747949974978593541529463344548800446917862266219189049856550539417324579114258210080798360122994007305091566363663241781504651372764226027210216355916383975880112316706422502404691353489765771310270171473497918954906308690817673196552680498374521519566949221302301125182104198985782657283395055909134373469597836420671163965867038455758131344733786842283328454828820406016508955409107145350345035248825315933976893356673777910251028486191789752627573225093968284278302684745743589192378470115772764709506475265246795419324395050366115533203601201395969892207
 
     public_numbers = rsa.RSAPublicNumbers(e, n)
-    numbers = rsa.RSAPrivateNumbers(p, q, d, dmp1, dmq1, iqmp,
-                                    public_numbers)
+    numbers = rsa.RSAPrivateNumbers(p, q, d, dmp1, dmq1, iqmp, public_numbers)
     key = default_backend().load_rsa_private_numbers(numbers)
 
     return key
 
 
 class TestPSHost(object):
-
-    @pytest.mark.parametrize('wsman_conn',
-                             # The actual culture can vary from host to host
-                             [[True, 'test_psrp_pshost_methods']],
-                             indirect=True)
+    @pytest.mark.parametrize(
+        "wsman_conn",
+        # The actual culture can vary from host to host
+        [[True, "test_psrp_pshost_methods"]],
+        indirect=True,
+    )
     def test_psrp_pshost_methods(self, wsman_conn):
         host = PSHost(None, None, False, "host name", None, None, "1.0")
 
@@ -56,7 +60,7 @@ class TestPSHost(object):
             ps = PowerShell(pool)
             # SetShouldExit is really the only one that seems to work so
             # we will just test that
-            ps.add_script('$host.CurrentCulture; $host.SetShouldExit(1)')
+            ps.add_script("$host.CurrentCulture; $host.SetShouldExit(1)")
             actual = ps.invoke()
             assert len(actual) == 1
             assert str(actual[0]) == "en-US"
@@ -73,8 +77,7 @@ class TestPSHost(object):
     def test_pshost_methods(self):
         wsman = WSMan("server")
         runspace = RunspacePool(wsman)
-        host = PSHost(CultureInfo(), CultureInfo(), True, "name", None, None,
-                      "1.0")
+        host = PSHost(CultureInfo(), CultureInfo(), True, "name", None, None, "1.0")
 
         assert host.GetName(None, None) == "name"
         actual_version = host.GetVersion(runspace, None)
@@ -93,33 +96,31 @@ class TestPSHost(object):
 
 
 class TestPSHostUserInterface(object):
-
-    @pytest.mark.parametrize('wsman_conn',
-                             [[True, 'test_psrp_pshost_ui_mocked_methods']],
-                             indirect=True)
-    def test_psrp_pshost_ui_mocked_methods(self, wsman_conn, monkeypatch):
+    @pytest.mark.parametrize("wsman_conn", [[True, "test_psrp_pshost_ui_mocked_methods"]], indirect=True)
+    def test_psrp_pshost_ui_mocked_methods(self, wsman_conn, monkeypatch, mocker):
         # This tests that the args from an actual host call match up with our
         # definitions
-        monkeypatch.setattr('cryptography.hazmat.primitives.asymmetric.rsa.'
-                            'generate_private_key', gen_rsa_keypair)
+        monkeypatch.setattr("cryptography.hazmat.primitives.asymmetric.rsa.generate_private_key", gen_rsa_keypair)
 
-        mock_read_line = MagicMock(return_value="ReadLine response")
-        mock_read_line_as_ss = MagicMock()
-        mock_write1 = MagicMock(return_value=None)
-        mock_write2 = MagicMock(return_value=None)
-        mock_write_line1 = MagicMock(return_value=None)
-        mock_write_line2 = MagicMock(return_value=None)
-        mock_write_line3 = MagicMock(return_value=None)
-        mock_write_error = MagicMock(return_value=None)
-        mock_write_debug = MagicMock(return_value=None)
-        mock_write_progress = MagicMock(return_value=None)
-        mock_write_verbose = MagicMock(return_value=None)
-        mock_write_warning = MagicMock(return_value=None)
-        mock_prompt = MagicMock(return_value={
-            "prompt field": "prompt response",
-        })
-        mock_prompt_credential = MagicMock()
-        mock_prompt_choice = MagicMock(return_value=1)
+        mock_read_line = mocker.MagicMock(return_value="ReadLine response")
+        mock_read_line_as_ss = mocker.MagicMock()
+        mock_write1 = mocker.MagicMock(return_value=None)
+        mock_write2 = mocker.MagicMock(return_value=None)
+        mock_write_line1 = mocker.MagicMock(return_value=None)
+        mock_write_line2 = mocker.MagicMock(return_value=None)
+        mock_write_line3 = mocker.MagicMock(return_value=None)
+        mock_write_error = mocker.MagicMock(return_value=None)
+        mock_write_debug = mocker.MagicMock(return_value=None)
+        mock_write_progress = mocker.MagicMock(return_value=None)
+        mock_write_verbose = mocker.MagicMock(return_value=None)
+        mock_write_warning = mocker.MagicMock(return_value=None)
+        mock_prompt = mocker.MagicMock(
+            return_value={
+                "prompt field": "prompt response",
+            }
+        )
+        mock_prompt_credential = mocker.MagicMock()
+        mock_prompt_choice = mocker.MagicMock(return_value=1)
 
         host_ui = PSHostUserInterface()
         host_ui.ReadLine = mock_read_line
@@ -143,15 +144,13 @@ class TestPSHostUserInterface(object):
 
         with RunspacePool(wsman_conn, host=host) as pool:
             pool.exchange_keys()
-            mock_read_line_as_ss.return_value = pool.serialize(
-                u"ReadLineAsSecureString response", ObjectMeta("SS")
-            )
-            mock_ps_credential = PSCredential(username="username",
-                                              password=u"password")
+            mock_read_line_as_ss.return_value = pool.serialize(u"ReadLineAsSecureString response", ObjectMeta("SS"))
+            mock_ps_credential = PSCredential(username="username", password=u"password")
             mock_prompt_credential.return_value = mock_ps_credential
 
             ps = PowerShell(pool)
-            ps.add_script('''$host.UI.ReadLine()
+            ps.add_script(
+                """$host.UI.ReadLine()
 $host.UI.ReadLineAsSecureString()
 $host.UI.Write("Write1")
 $host.UI.Write([System.ConsoleColor]::Blue, [System.ConsoleColor]::White, "Write2")
@@ -172,7 +171,8 @@ $host.UI.PromptForCredential("PromptForCredential caption", "PromptForCredential
 
 $choice_field1 = New-Object -TypeName System.Management.Automation.Host.ChoiceDescription -ArgumentList "Prompt1 label", "Prompt1 help"
 $choice_field2 = New-Object -TypeName System.Management.Automation.Host.ChoiceDescription -ArgumentList "Prompt2 label", "Prompt2 help"
-$host.UI.PromptForChoice("PromptForChoice caption", "PromptForChoice message", @($choice_field1, $choice_field2), 0)''')
+$host.UI.PromptForChoice("PromptForChoice caption", "PromptForChoice message", @($choice_field1, $choice_field2), 0)"""
+            )
             actual = ps.invoke()
 
         assert len(actual) == 5
@@ -184,8 +184,7 @@ $host.UI.PromptForChoice("PromptForChoice caption", "PromptForChoice message", @
 
         assert actual[1] == "ReadLineAsSecureString response"
         assert mock_read_line_as_ss.call_count == 1
-        assert isinstance(mock_read_line_as_ss.call_args[0][0],
-                          RunspacePool)
+        assert isinstance(mock_read_line_as_ss.call_args[0][0], RunspacePool)
         assert isinstance(mock_read_line_as_ss.call_args[0][1], PowerShell)
 
         assert mock_write1.call_count == 1
@@ -234,9 +233,7 @@ $host.UI.PromptForChoice("PromptForChoice caption", "PromptForChoice message", @
         assert isinstance(progress_args[0][0], RunspacePool)
         assert isinstance(progress_args[0][1], PowerShell)
         assert progress_args[0][2] == 1
-        progress_record = pool._serializer.deserialize(
-            progress_args[0][3], ObjectMeta("Obj", object=ProgressRecord)
-        )
+        progress_record = pool._serializer.deserialize(progress_args[0][3], ObjectMeta("Obj", object=ProgressRecord))
         assert progress_record.activity == "activity"
         assert progress_record.activity_id == 2
         assert progress_record.description == "description"
@@ -259,27 +256,19 @@ $host.UI.PromptForChoice("PromptForChoice caption", "PromptForChoice message", @
         assert mock_prompt.call_args[0][3] == "Prompt message"
         assert isinstance(mock_prompt.call_args[0][4], list)
         assert len(mock_prompt.call_args[0][4]) == 1
-        assert mock_prompt.call_args[0][4][0].extended_properties['name'] == \
-            'prompt field'
-        assert mock_prompt.call_args[0][4][0].extended_properties['label'] == \
-            'PromptLabel'
+        assert mock_prompt.call_args[0][4][0].extended_properties["name"] == "prompt field"
+        assert mock_prompt.call_args[0][4][0].extended_properties["label"] == "PromptLabel"
 
         assert isinstance(actual[3], PSCredential)
         assert actual[3].username == "username"
         assert actual[3].password == "password"
         assert mock_prompt_credential.call_count == 1
-        assert isinstance(mock_prompt_credential.call_args[0][0],
-                          RunspacePool)
-        assert isinstance(mock_prompt_credential.call_args[0][1],
-                          PowerShell)
-        assert mock_prompt_credential.call_args[0][2] == \
-            "PromptForCredential caption"
-        assert mock_prompt_credential.call_args[0][3] == \
-            "PromptForCredential message"
-        assert mock_prompt_credential.call_args[0][4] == \
-            "PromptForCredential user"
-        assert mock_prompt_credential.call_args[0][5] == \
-            "PromptForCredential target"
+        assert isinstance(mock_prompt_credential.call_args[0][0], RunspacePool)
+        assert isinstance(mock_prompt_credential.call_args[0][1], PowerShell)
+        assert mock_prompt_credential.call_args[0][2] == "PromptForCredential caption"
+        assert mock_prompt_credential.call_args[0][3] == "PromptForCredential message"
+        assert mock_prompt_credential.call_args[0][4] == "PromptForCredential user"
+        assert mock_prompt_credential.call_args[0][5] == "PromptForCredential target"
         assert mock_prompt_credential.call_args[0][6] == 3
         assert mock_prompt_credential.call_args[0][7] == 1
 
@@ -291,14 +280,10 @@ $host.UI.PromptForChoice("PromptForChoice caption", "PromptForChoice message", @
         assert mock_prompt_choice.call_args[0][3] == "PromptForChoice message"
         assert isinstance(mock_prompt_choice.call_args[0][4], list)
         assert len(mock_prompt_choice.call_args[0][4]) == 2
-        assert mock_prompt_choice.call_args[0][4][0].extended_properties[
-            'label'] == "Prompt1 label"
-        assert mock_prompt_choice.call_args[0][4][0].extended_properties[
-            'helpMessage'] == "Prompt1 help"
-        assert mock_prompt_choice.call_args[0][4][1].extended_properties[
-            'label'] == "Prompt2 label"
-        assert mock_prompt_choice.call_args[0][4][1].extended_properties[
-            'helpMessage'] == "Prompt2 help"
+        assert mock_prompt_choice.call_args[0][4][0].extended_properties["label"] == "Prompt1 label"
+        assert mock_prompt_choice.call_args[0][4][0].extended_properties["helpMessage"] == "Prompt1 help"
+        assert mock_prompt_choice.call_args[0][4][1].extended_properties["label"] == "Prompt2 label"
+        assert mock_prompt_choice.call_args[0][4][1].extended_properties["helpMessage"] == "Prompt2 help"
 
     def test_ps_host_ui_implemented(self):
         ui = PSHostUserInterface()
@@ -358,43 +343,36 @@ $host.UI.PromptForChoice("PromptForChoice caption", "PromptForChoice message", @
             ui.PromptForCredential1(None, None, None, None, None, None)
 
         with pytest.raises(NotImplementedError):
-            ui.PromptForCredential2(None, None, None, None, None, None, None,
-                                    None)
+            ui.PromptForCredential2(None, None, None, None, None, None, None, None)
 
         with pytest.raises(NotImplementedError):
             ui.PromptForChoice(None, None, None, None, None, None)
 
 
 class TestPSHostRawUserInterface(object):
-
-    @pytest.mark.parametrize(
-        'wsman_conn', [[True, 'test_psrp_pshost_raw_ui_mocked_methods']],
-        indirect=True
-    )
-    def test_psrp_pshost_raw_ui_mocked_methods(self, wsman_conn,
-                                               monkeypatch):
+    @pytest.mark.parametrize("wsman_conn", [[True, "test_psrp_pshost_raw_ui_mocked_methods"]], indirect=True)
+    def test_psrp_pshost_raw_ui_mocked_methods(self, wsman_conn, monkeypatch, mocker):
         # in a mocked context the calculated size differs on a few variables
         # we will mock out that call and return the ones used in our existing
         # responses
-        mock_calc = MagicMock()
+        mock_calc = mocker.MagicMock()
         mock_calc.side_effect = [113955, 382750]
 
-        key_info = KeyInfo(code=65, character="a",
-                           state=ControlKeyState.CapsLockOn, key_down=True)
+        key_info = KeyInfo(code=65, character="a", state=ControlKeyState.CapsLockOn, key_down=True)
 
-        set_foreground_color = MagicMock(return_value=None)
-        set_background_color = MagicMock(return_value=None)
-        set_cursor_position = MagicMock(return_value=None)
-        set_window_position = MagicMock(return_value=None)
-        set_cursor_size = MagicMock(return_value=None)
-        set_buffer_size = MagicMock(return_value=None)
-        set_window_size = MagicMock(return_value=None)
-        set_window_title = MagicMock(return_value=None)
-        read_key = MagicMock(return_value=key_info)
-        flush_input = MagicMock(return_value=None)
-        set_buffer1 = MagicMock(return_value=None)
-        set_buffer2 = MagicMock(return_value=None)
-        scroll_buffer = MagicMock(return_value=None)
+        set_foreground_color = mocker.MagicMock(return_value=None)
+        set_background_color = mocker.MagicMock(return_value=None)
+        set_cursor_position = mocker.MagicMock(return_value=None)
+        set_window_position = mocker.MagicMock(return_value=None)
+        set_cursor_size = mocker.MagicMock(return_value=None)
+        set_buffer_size = mocker.MagicMock(return_value=None)
+        set_window_size = mocker.MagicMock(return_value=None)
+        set_window_title = mocker.MagicMock(return_value=None)
+        read_key = mocker.MagicMock(return_value=key_info)
+        flush_input = mocker.MagicMock(return_value=None)
+        set_buffer1 = mocker.MagicMock(return_value=None)
+        set_buffer2 = mocker.MagicMock(return_value=None)
+        scroll_buffer = mocker.MagicMock(return_value=None)
 
         window_title = "pypsrp window"
         cursor_size = 50
@@ -407,12 +385,18 @@ class TestPSHostRawUserInterface(object):
         max_window_size = Size(width=80, height=80)
         window_size = Size(width=80, height=80)
 
-        host_raw_ui = PSHostRawUserInterface(window_title, cursor_size,
-                                             foreground_color,
-                                             background_color, cursor_position,
-                                             window_position, buffer_size,
-                                             max_physical_window_size,
-                                             max_window_size, window_size)
+        host_raw_ui = PSHostRawUserInterface(
+            window_title,
+            cursor_size,
+            foreground_color,
+            background_color,
+            cursor_position,
+            window_position,
+            buffer_size,
+            max_physical_window_size,
+            max_window_size,
+            window_size,
+        )
         host_raw_ui.SetForegroundColor = set_foreground_color
         host_raw_ui.SetBackgroundColor = set_background_color
         host_raw_ui.SetCursorPosition = set_cursor_position
@@ -432,7 +416,8 @@ class TestPSHostRawUserInterface(object):
 
         with RunspacePool(wsman_conn, host=host) as pool:
             ps = PowerShell(pool)
-            ps.add_script('''$host.UI.RawUI.ForegroundColor
+            ps.add_script(
+                """$host.UI.RawUI.ForegroundColor
 $host.UI.RawUI.ForegroundColor = [System.ConsoleColor]::Green
 $host.UI.RawUI.ForegroundColor
 
@@ -486,7 +471,8 @@ $cells[1,1] = $buffer_cell2_2
 $cells[1,0] = $buffer_cell2_1
 $host.UI.RawUI.SetBufferContents($coordinates, $cells)
 
-$host.UI.RawUI.ScrollBufferContents($rectangle, $coordinates, $rectangle, $buffer_cell)''')
+$host.UI.RawUI.ScrollBufferContents($rectangle, $coordinates, $rectangle, $buffer_cell)"""
+            )
             actual = ps.invoke()
 
         assert len(actual) == 17
@@ -510,20 +496,16 @@ $host.UI.RawUI.ScrollBufferContents($rectangle, $coordinates, $rectangle, $buffe
         assert set_cursor_position.call_count == 1
         assert isinstance(set_cursor_position.call_args[0][0], RunspacePool)
         assert isinstance(set_cursor_position.call_args[0][1], PowerShell)
-        assert set_cursor_position.call_args[0][2].extended_properties['x'] \
-            == 11
-        assert set_cursor_position.call_args[0][2].extended_properties['y'] \
-            == 12
+        assert set_cursor_position.call_args[0][2].extended_properties["x"] == 11
+        assert set_cursor_position.call_args[0][2].extended_properties["y"] == 12
 
         assert str(actual[6]) == "3,4"
         assert str(actual[7]) == "13,14"
         assert set_window_position.call_count == 1
         assert isinstance(set_window_position.call_args[0][0], RunspacePool)
         assert isinstance(set_window_position.call_args[0][1], PowerShell)
-        assert set_window_position.call_args[0][2].extended_properties['x'] \
-            == 13
-        assert set_window_position.call_args[0][2].extended_properties['y'] \
-            == 14
+        assert set_window_position.call_args[0][2].extended_properties["x"] == 13
+        assert set_window_position.call_args[0][2].extended_properties["y"] == 14
 
         assert actual[8] == 50
         assert actual[9] == 25
@@ -537,24 +519,18 @@ $host.UI.RawUI.ScrollBufferContents($rectangle, $coordinates, $rectangle, $buffe
         assert set_buffer_size.call_count == 1
         assert isinstance(set_buffer_size.call_args[0][0], RunspacePool)
         assert isinstance(set_buffer_size.call_args[0][1], PowerShell)
-        assert isinstance(set_buffer_size.call_args[0][2],
-                          GenericComplexObject)
-        assert set_buffer_size.call_args[0][2].extended_properties['width'] \
-            == 8
-        assert set_buffer_size.call_args[0][2].extended_properties['height'] \
-            == 9
+        assert isinstance(set_buffer_size.call_args[0][2], GenericComplexObject)
+        assert set_buffer_size.call_args[0][2].extended_properties["width"] == 8
+        assert set_buffer_size.call_args[0][2].extended_properties["height"] == 9
 
         assert str(actual[12]) == "80,80"
         assert str(actual[13]) == "8,9"
         assert set_window_size.call_count == 1
         assert isinstance(set_window_size.call_args[0][0], RunspacePool)
         assert isinstance(set_window_size.call_args[0][1], PowerShell)
-        assert isinstance(set_window_size.call_args[0][2],
-                          GenericComplexObject)
-        assert set_window_size.call_args[0][2].extended_properties['width'] \
-            == 8
-        assert set_window_size.call_args[0][2].extended_properties['height'] \
-            == 9
+        assert isinstance(set_window_size.call_args[0][2], GenericComplexObject)
+        assert set_window_size.call_args[0][2].extended_properties["width"] == 8
+        assert set_window_size.call_args[0][2].extended_properties["height"] == 9
 
         assert actual[14] == "pypsrp window"
         assert actual[15] == "New Window Title"
@@ -578,69 +554,69 @@ $host.UI.RawUI.ScrollBufferContents($rectangle, $coordinates, $rectangle, $buffe
         assert isinstance(set_buffer1.call_args[0][0], RunspacePool)
         assert isinstance(set_buffer1.call_args[0][1], PowerShell)
         assert isinstance(set_buffer1.call_args[0][2], GenericComplexObject)
-        assert set_buffer1.call_args[0][2].extended_properties['left'] == 1
-        assert set_buffer1.call_args[0][2].extended_properties['top'] == 2
-        assert set_buffer1.call_args[0][2].extended_properties['right'] == 3
-        assert set_buffer1.call_args[0][2].extended_properties['bottom'] == 4
+        assert set_buffer1.call_args[0][2].extended_properties["left"] == 1
+        assert set_buffer1.call_args[0][2].extended_properties["top"] == 2
+        assert set_buffer1.call_args[0][2].extended_properties["right"] == 3
+        assert set_buffer1.call_args[0][2].extended_properties["bottom"] == 4
         fill = set_buffer1.call_args[0][3]
         assert isinstance(fill, GenericComplexObject)
-        assert fill.extended_properties['character'] == "Z"
-        assert fill.extended_properties['foregroundColor'] == 12
-        assert fill.extended_properties['backgroundColor'] == 10
-        assert fill.extended_properties['bufferCellType'] == 0
+        assert fill.extended_properties["character"] == "Z"
+        assert fill.extended_properties["foregroundColor"] == 12
+        assert fill.extended_properties["backgroundColor"] == 10
+        assert fill.extended_properties["bufferCellType"] == 0
 
         assert set_buffer2.call_count == 1
         assert isinstance(set_buffer2.call_args[0][0], RunspacePool)
         assert isinstance(set_buffer2.call_args[0][1], PowerShell)
         assert isinstance(set_buffer2.call_args[0][2], GenericComplexObject)
-        assert set_buffer2.call_args[0][2].extended_properties['x'] == 15
-        assert set_buffer2.call_args[0][2].extended_properties['y'] == 15
+        assert set_buffer2.call_args[0][2].extended_properties["x"] == 15
+        assert set_buffer2.call_args[0][2].extended_properties["y"] == 15
         assert isinstance(set_buffer2.call_args[0][3], GenericComplexObject)
-        assert set_buffer2.call_args[0][3].extended_properties['mal'] == [2, 2]
-        set_contents = set_buffer2.call_args[0][3].extended_properties['mae']
+        assert set_buffer2.call_args[0][3].extended_properties["mal"] == [2, 2]
+        set_contents = set_buffer2.call_args[0][3].extended_properties["mae"]
         assert len(set_contents) == 4
-        assert set_contents[0].extended_properties['character'] == "A"
-        assert set_contents[0].extended_properties['foregroundColor'] == 0
-        assert set_contents[0].extended_properties['backgroundColor'] == 15
-        assert set_contents[0].extended_properties['bufferCellType'] == 1
-        assert set_contents[1].extended_properties['character'] == "B"
-        assert set_contents[1].extended_properties['foregroundColor'] == 0
-        assert set_contents[1].extended_properties['backgroundColor'] == 15
-        assert set_contents[1].extended_properties['bufferCellType'] == 2
-        assert set_contents[2].extended_properties['character'] == "C"
-        assert set_contents[2].extended_properties['foregroundColor'] == 0
-        assert set_contents[2].extended_properties['backgroundColor'] == 15
-        assert set_contents[2].extended_properties['bufferCellType'] == 1
-        assert set_contents[3].extended_properties['character'] == "D"
-        assert set_contents[3].extended_properties['foregroundColor'] == 0
-        assert set_contents[3].extended_properties['backgroundColor'] == 15
-        assert set_contents[3].extended_properties['bufferCellType'] == 2
+        assert set_contents[0].extended_properties["character"] == "A"
+        assert set_contents[0].extended_properties["foregroundColor"] == 0
+        assert set_contents[0].extended_properties["backgroundColor"] == 15
+        assert set_contents[0].extended_properties["bufferCellType"] == 1
+        assert set_contents[1].extended_properties["character"] == "B"
+        assert set_contents[1].extended_properties["foregroundColor"] == 0
+        assert set_contents[1].extended_properties["backgroundColor"] == 15
+        assert set_contents[1].extended_properties["bufferCellType"] == 2
+        assert set_contents[2].extended_properties["character"] == "C"
+        assert set_contents[2].extended_properties["foregroundColor"] == 0
+        assert set_contents[2].extended_properties["backgroundColor"] == 15
+        assert set_contents[2].extended_properties["bufferCellType"] == 1
+        assert set_contents[3].extended_properties["character"] == "D"
+        assert set_contents[3].extended_properties["foregroundColor"] == 0
+        assert set_contents[3].extended_properties["backgroundColor"] == 15
+        assert set_contents[3].extended_properties["bufferCellType"] == 2
 
         assert scroll_buffer.call_count == 1
         assert isinstance(scroll_buffer.call_args[0][0], RunspacePool)
         assert isinstance(scroll_buffer.call_args[0][1], PowerShell)
         source = scroll_buffer.call_args[0][2]
         assert isinstance(source, GenericComplexObject)
-        assert source.extended_properties['left'] == 1
-        assert source.extended_properties['top'] == 2
-        assert source.extended_properties['right'] == 3
-        assert source.extended_properties['bottom'] == 4
+        assert source.extended_properties["left"] == 1
+        assert source.extended_properties["top"] == 2
+        assert source.extended_properties["right"] == 3
+        assert source.extended_properties["bottom"] == 4
         destination = scroll_buffer.call_args[0][3]
         assert isinstance(destination, GenericComplexObject)
-        assert destination.extended_properties['x'] == 15
-        assert destination.extended_properties['y'] == 15
+        assert destination.extended_properties["x"] == 15
+        assert destination.extended_properties["y"] == 15
         clip = scroll_buffer.call_args[0][4]
         assert isinstance(clip, GenericComplexObject)
-        assert clip.extended_properties['left'] == 1
-        assert clip.extended_properties['top'] == 2
-        assert clip.extended_properties['right'] == 3
-        assert clip.extended_properties['bottom'] == 4
+        assert clip.extended_properties["left"] == 1
+        assert clip.extended_properties["top"] == 2
+        assert clip.extended_properties["right"] == 3
+        assert clip.extended_properties["bottom"] == 4
         fill = scroll_buffer.call_args[0][5]
         assert isinstance(fill, GenericComplexObject)
-        assert fill.extended_properties['character'] == "Z"
-        assert fill.extended_properties['foregroundColor'] == 12
-        assert fill.extended_properties['backgroundColor'] == 10
-        assert fill.extended_properties['bufferCellType'] == 0
+        assert fill.extended_properties["character"] == "Z"
+        assert fill.extended_properties["foregroundColor"] == 12
+        assert fill.extended_properties["backgroundColor"] == 10
+        assert fill.extended_properties["bufferCellType"] == 0
 
     def test_ps_host_raw_ui_method(self):
         window_title = "pypsrp window"
@@ -655,9 +631,16 @@ $host.UI.RawUI.ScrollBufferContents($rectangle, $coordinates, $rectangle, $buffe
         window_size = Size(width=80, height=80)
 
         raw_ui = PSHostRawUserInterface(
-            window_title, cursor_size, foreground_color, background_color,
-            cursor_position, window_position, buffer_size,
-            max_physical_window_size, max_window_size, window_size
+            window_title,
+            cursor_size,
+            foreground_color,
+            background_color,
+            cursor_position,
+            window_position,
+            buffer_size,
+            max_physical_window_size,
+            max_window_size,
+            window_size,
         )
 
         actual_foreground_color = raw_ui.GetForegroundColor(None, None)
@@ -673,8 +656,8 @@ $host.UI.RawUI.ScrollBufferContents($rectangle, $coordinates, $rectangle, $buffe
         assert raw_ui.background_color.value == Color.DARK_MAGENTA
 
         coordinates = GenericComplexObject()
-        coordinates.extended_properties['x'] = 11
-        coordinates.extended_properties['y'] = 12
+        coordinates.extended_properties["x"] = 11
+        coordinates.extended_properties["y"] = 12
 
         actual_cursor_position = raw_ui.GetCursorPosition(None, None)
         assert actual_cursor_position == cursor_position
@@ -696,8 +679,8 @@ $host.UI.RawUI.ScrollBufferContents($rectangle, $coordinates, $rectangle, $buffe
         assert raw_ui.cursor_size == 25
 
         size = GenericComplexObject()
-        size.extended_properties['height'] = 160
-        size.extended_properties['width'] = 160
+        size.extended_properties["height"] = 160
+        size.extended_properties["width"] = 160
 
         actual_buffer_size = raw_ui.GetBufferSize(None, None)
         assert actual_buffer_size == buffer_size
@@ -721,8 +704,7 @@ $host.UI.RawUI.ScrollBufferContents($rectangle, $coordinates, $rectangle, $buffe
         actual_max_window_size = raw_ui.GetMaxWindowSize(None, None)
         assert actual_max_window_size == max_window_size
 
-        actual_physical_window_size = raw_ui.GetMaxPhysicalWindowSize(None,
-                                                                      None)
+        actual_physical_window_size = raw_ui.GetMaxPhysicalWindowSize(None, None)
         assert actual_physical_window_size == max_physical_window_size
 
         raw_ui.key_available = True
@@ -732,29 +714,27 @@ $host.UI.RawUI.ScrollBufferContents($rectangle, $coordinates, $rectangle, $buffe
         raw_ui.FlushInputBuffer(None, None)
 
         rectangle = GenericComplexObject()
-        rectangle.extended_properties['left'] = 1
-        rectangle.extended_properties['top'] = 2
-        rectangle.extended_properties['right'] = 3
-        rectangle.extended_properties['bottom'] = 4
+        rectangle.extended_properties["left"] = 1
+        rectangle.extended_properties["top"] = 2
+        rectangle.extended_properties["right"] = 3
+        rectangle.extended_properties["bottom"] = 4
 
         fill = GenericComplexObject()
-        fill.extended_properties['character'] = "A"
-        fill.extended_properties['foregroundColor'] = 12
-        fill.extended_properties['backgroundColor'] = 10
-        fill.extended_properties['bufferCellType'] = 0
+        fill.extended_properties["character"] = "A"
+        fill.extended_properties["foregroundColor"] = 12
+        fill.extended_properties["backgroundColor"] = 10
+        fill.extended_properties["bufferCellType"] = 0
 
         contents = GenericComplexObject()
-        contents.extended_properties['mal'] = [2, 2]
-        contents.extended_properties['mae'] = [[fill, fill], [fill, fill]]
+        contents.extended_properties["mal"] = [2, 2]
+        contents.extended_properties["mae"] = [[fill, fill], [fill, fill]]
 
         raw_ui.SetBufferContents1(None, None, rectangle, fill)
         raw_ui.SetBufferContents2(None, None, coordinates, contents)
-        raw_ui.ScrollBufferContents(None, None, rectangle, coordinates,
-                                    rectangle, fill)
+        raw_ui.ScrollBufferContents(None, None, rectangle, coordinates, rectangle, fill)
 
     def test_ps_host_raw_ui_not_implemented(self):
-        raw_ui = PSHostRawUserInterface(None, None, None, None, None, None,
-                                        None, None, None, None)
+        raw_ui = PSHostRawUserInterface(None, None, None, None, None, None, None, None, None, None)
 
         with pytest.raises(NotImplementedError):
             raw_ui.ReadKey(None, None)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -8,7 +8,7 @@ from pypsrp.shell import Process, SignalCode, WinRS
 from pypsrp.wsman import WSMan
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def functional_transports():
     """
     This runs the same test over multiple auth providers and on SSL/Without.
@@ -35,23 +35,22 @@ def functional_transports():
 
     Each http test has message encryption enabled while the https tests do not.
     """
-    run = os.environ.get('PYPSRP_RUN_INTEGRATION', None)
+    run = os.environ.get("PYPSRP_RUN_INTEGRATION", None)
     if run is None:
-        pytest.skip("Skipping CI functional tests because "
-                    "PYPSRP_RUN_INTEGRATION has not been set")
+        pytest.skip("Skipping CI functional tests because PYPSRP_RUN_INTEGRATION has not been set")
 
-    username = os.environ['PYPSRP_USERNAME']
-    password = os.environ['PYPSRP_PASSWORD']
-    server = os.environ['PYPSRP_SERVER']
-    cert_dir = os.environ.get('PYPSRP_CERT_DIR', None)
-    http_port = int(os.environ.get('PYPSRP_HTTP_PORT', 5985))
-    https_port = int(os.environ.get('PYPSRP_HTTPS_PORT', 5986))
+    username = os.environ["PYPSRP_USERNAME"]
+    password = os.environ["PYPSRP_PASSWORD"]
+    server = os.environ["PYPSRP_SERVER"]
+    cert_dir = os.environ.get("PYPSRP_CERT_DIR", None)
+    http_port = int(os.environ.get("PYPSRP_HTTP_PORT", 5985))
+    https_port = int(os.environ.get("PYPSRP_HTTPS_PORT", 5986))
 
     # can't really test kerberos in CI so it is missing from this list
-    auths = ['negotiate', 'ntlm', 'credssp']
-    auths_ssl = ['basic']
+    auths = ["negotiate", "ntlm", "credssp"]
+    auths_ssl = ["basic"]
     if cert_dir is not None:
-        auths_ssl.append('certificate')
+        auths_ssl.append("certificate")
         cert_key_pem = os.path.join(cert_dir, "cert_key.pem")
         cert_pem = os.path.join(cert_dir, "cert.pem")
     else:
@@ -61,21 +60,26 @@ def functional_transports():
 
     wsmans = []
     for auth in auths:
-        wsman = WSMan(server, username=username, password=password, ssl=False,
-                      auth=auth, port=http_port)
+        wsman = WSMan(server, username=username, password=password, ssl=False, auth=auth, port=http_port)
         wsmans.append(wsman)
 
     for auth in auths_ssl:
-        wsman = WSMan(server, username=username, password=password, ssl=True,
-                      auth=auth, cert_validation=False,
-                      certificate_key_pem=cert_key_pem,
-                      certificate_pem=cert_pem, port=https_port)
+        wsman = WSMan(
+            server,
+            username=username,
+            password=password,
+            ssl=True,
+            auth=auth,
+            cert_validation=False,
+            certificate_key_pem=cert_key_pem,
+            certificate_pem=cert_pem,
+            port=https_port,
+        )
         wsmans.append(wsman)
     yield wsmans
 
 
 class TestPowerShellFunctional(object):
-
     def test_winrs(self, functional_transports):
         for wsman in functional_transports:
             with wsman, WinRS(wsman) as shell:
@@ -111,8 +115,7 @@ class TestPowerShellFunctional(object):
 
                 large_string = "hello world " * 3000
                 ps.add_statement()
-                ps.add_script("$VerbosePreference = 'Continue'; "
-                              "Write-Verbose '%s'" % large_string)
+                ps.add_script("$VerbosePreference = 'Continue'; Write-Verbose '%s'" % large_string)
 
                 actual = ps.invoke()
 
@@ -130,18 +133,15 @@ class TestPowerShellFunctional(object):
                 wsman_path = "WSMan:\\localhost\\Service\\AllowUnencrypted"
                 ps.add_cmdlet("Get-Item").add_parameter("Path", wsman_path)
                 ps.add_statement()
-                ps.add_cmdlet("Set-Item").add_parameters({
-                    "Path": wsman_path,
-                    "Value": "True"
-                })
+                ps.add_cmdlet("Set-Item").add_parameters({"Path": wsman_path, "Value": "True"})
                 actual = ps.invoke()
 
             assert ps.had_errors is True
             assert len(actual) == 1
-            assert actual[0].property_sets[0].adapted_properties['Value'] == \
-                'false'
-            assert str(ps.streams.error[0]) == \
-                "The term 'Set-Item' is not recognized as the name of a " \
-                "cmdlet, function, script file, or operable program. Check " \
-                "the spelling of the name, or if a path was included, " \
+            assert actual[0].property_sets[0].adapted_properties["Value"] == "false"
+            assert (
+                str(ps.streams.error[0]) == "The term 'Set-Item' is not recognized as the name of a "
+                "cmdlet, function, script file, or operable program. Check "
+                "the spelling of the name, or if a path was included, "
                 "verify that the path is correct and try again."
+            )

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -1,14 +1,20 @@
 import uuid
 
 from pypsrp.complex_objects import HostMethodIdentifier, ObjectMeta
-from pypsrp.messages import ErrorRecordMessage, Message, MessageType, \
-    PublicKeyRequest, RunspacePoolHostCall, RunspacePoolHostResponse, \
-    UserEvent, WarningRecord
+from pypsrp.messages import (
+    ErrorRecordMessage,
+    Message,
+    MessageType,
+    PublicKeyRequest,
+    RunspacePoolHostCall,
+    RunspacePoolHostResponse,
+    UserEvent,
+    WarningRecord,
+)
 from pypsrp.serializer import Serializer
 
 
 class TestPublicKeyRequest(object):
-
     def test_create_public_key_request(self):
         pub_key_req = PublicKeyRequest()
         empty_uuid = "00000000-0000-0000-0000-000000000000"
@@ -17,31 +23,33 @@ class TestPublicKeyRequest(object):
 
         msg = Message(0x2, empty_uuid, empty_uuid, pub_key_req, serializer)
         actual = msg.pack()
-        assert actual == b"\x02\x00\x00\x00" \
-                         b"\x07\x00\x01\x00" \
-                         b"\x00\x00\x00\x00\x00\x00\x00\x00" \
-                         b"\x00\x00\x00\x00\x00\x00\x00\x00" \
-                         b"\x00\x00\x00\x00\x00\x00\x00\x00" \
-                         b"\x00\x00\x00\x00\x00\x00\x00\x00" + \
-                         expected
+        assert (
+            actual == b"\x02\x00\x00\x00"
+            b"\x07\x00\x01\x00"
+            b"\x00\x00\x00\x00\x00\x00\x00\x00"
+            b"\x00\x00\x00\x00\x00\x00\x00\x00"
+            b"\x00\x00\x00\x00\x00\x00\x00\x00"
+            b"\x00\x00\x00\x00\x00\x00\x00\x00" + expected
+        )
 
     def test_parse_public_key_request(self):
-        data = b"\x02\x00\x00\x00" \
-               b"\x07\x00\x01\x00" \
-               b"\x00\x00\x00\x00\x00\x00\x00\x00" \
-               b"\x00\x00\x00\x00\x00\x00\x00\x00" \
-               b"\x00\x00\x00\x00\x00\x00\x00\x00" \
-               b"\x00\x00\x00\x00\x00\x00\x00\x00" \
-               b"<S />"
+        data = (
+            b"\x02\x00\x00\x00"
+            b"\x07\x00\x01\x00"
+            b"\x00\x00\x00\x00\x00\x00\x00\x00"
+            b"\x00\x00\x00\x00\x00\x00\x00\x00"
+            b"\x00\x00\x00\x00\x00\x00\x00\x00"
+            b"\x00\x00\x00\x00\x00\x00\x00\x00"
+            b"<S />"
+        )
         actual = Message.unpack(data, Serializer())
         assert actual.message_type == MessageType.PUBLIC_KEY_REQUEST
         assert isinstance(actual.data, PublicKeyRequest)
 
 
 class TestUserEvent(object):
-
     def test_parse_msg(self):
-        xml = '''<Obj RefId="0">
+        xml = """<Obj RefId="0">
             <MS>
                 <I32 N="PSEventArgs.EventIdentifier">1</I32>
                 <S N="PSEventArgs.SourceIdentifier">ae6245f2-c179-4a9a-a039-47b60fc44500</S>
@@ -88,31 +96,28 @@ class TestUserEvent(object):
                 <Nil N="PSEventArgs.ComputerName"/>
                 <G N="PSEventArgs.RunspaceId">fb9c87e8-1190-40a7-a681-6fc9b9f84a17</G>
             </MS>
-        </Obj>'''
+        </Obj>"""
         serializer = Serializer()
         meta = ObjectMeta("Obj", object=UserEvent)
         actual = serializer.deserialize(xml, meta)
 
         assert str(actual.args[0]) == "System.Timers.Timer"
-        assert actual.args[0].adapted_properties['Interval'] == 5000.0
+        assert actual.args[0].adapted_properties["Interval"] == 5000.0
         assert str(actual.args[1]) == "System.Timers.ElapsedEventArgs"
-        assert actual.args[1].adapted_properties['SignalTime'] == \
-            "2009-06-17T10:57:23.1568275-07:00"
+        assert actual.args[1].adapted_properties["SignalTime"] == "2009-06-17T10:57:23.1568275-07:00"
         assert actual.computer is None
         assert actual.data is None
         assert actual.event_id == 1
-        assert actual.runspace_id == \
-            uuid.UUID("fb9c87e8-1190-40a7-a681-6fc9b9f84a17")
+        assert actual.runspace_id == uuid.UUID("fb9c87e8-1190-40a7-a681-6fc9b9f84a17")
         assert str(actual.sender) == "System.Timers.Timer"
-        assert actual.sender.adapted_properties['Interval'] == 5000.0
+        assert actual.sender.adapted_properties["Interval"] == 5000.0
         assert actual.source_id == "ae6245f2-c179-4a9a-a039-47b60fc44500"
         assert actual.time == "2009-06-17T10:57:23.1578277-07:00"
 
 
 class TestRunspacePoolHostCall(object):
-
     def test_parse_message(self):
-        xml = '''<Obj RefId="0">
+        xml = """<Obj RefId="0">
             <MS>
                 <I64 N="ci">1</I64>
                 <Obj N="mi" RefId="1">
@@ -133,7 +138,7 @@ class TestRunspacePoolHostCall(object):
                     <LST/>
                 </Obj>
             </MS>
-        </Obj>'''
+        </Obj>"""
         serializer = Serializer()
         meta = ObjectMeta("Obj", object=RunspacePoolHostCall)
         actual = serializer.deserialize(xml, meta)
@@ -145,9 +150,8 @@ class TestRunspacePoolHostCall(object):
 
 
 class TestRunspacePoolHostResponse(object):
-
     def test_parse_message(self):
-        xml = '''<Obj RefId="11">
+        xml = """<Obj RefId="11">
             <MS>
                 <S N="mr">Line read from the host</S>
                 <I64 N="ci">1</I64>
@@ -162,7 +166,7 @@ class TestRunspacePoolHostResponse(object):
                     <I32>11</I32>
                 </Obj>
             </MS>
-        </Obj>'''
+        </Obj>"""
         serializer = Serializer()
         meta = ObjectMeta("Obj", object=RunspacePoolHostResponse)
         actual = serializer.deserialize(xml, meta)
@@ -175,9 +179,8 @@ class TestRunspacePoolHostResponse(object):
 
 
 class TestErrorRecord(object):
-
     def test_parse_error(self):
-        xml = '''<Obj RefId="0">
+        xml = """<Obj RefId="0">
             <TN RefId="0">
                 <T>System.Management.Automation.ErrorRecord</T>
                 <T>System.Object</T>
@@ -325,38 +328,34 @@ class TestErrorRecord(object):
                 <S N="ErrorDetails_ScriptStackTrace">at &lt;ScriptBlock&gt;, &lt;No file&gt;: line 5</S>
                 <Nil N="PSMessageDetails"/>
             </MS>
-        </Obj>'''
+        </Obj>"""
         serializer = Serializer()
         meta = ObjectMeta("Obj", object=ErrorRecordMessage)
         actual = serializer.deserialize(xml, meta)
 
         assert str(actual) == "error stream"
-        assert actual.exception.adapted_properties['Message'] == "error stream"
-        assert actual.exception.adapted_properties['HResult'] == -2146233087
+        assert actual.exception.adapted_properties["Message"] == "error stream"
+        assert actual.exception.adapted_properties["HResult"] == -2146233087
         assert actual.target_object is None
-        assert actual.fq_error == \
-            "Microsoft.PowerShell.Commands.WriteErrorException"
+        assert actual.fq_error == "Microsoft.PowerShell.Commands.WriteErrorException"
         assert actual.invocation
         invoc_props = actual.invocation_info.adapted_properties
-        assert invoc_props['MyCommand'] == "Write-Error 'error stream'\n"
-        assert invoc_props['BoundParameters'] == {}
-        assert invoc_props['UnboundArguments'] == []
-        assert invoc_props['ScriptLineNumber'] == 0
-        assert invoc_props['OffsetInLine'] == 0
-        assert invoc_props['HistoryId'] == 1
-        assert invoc_props['CommandOrigin'] == 'Internal'
-        assert actual.fq_error == \
-            "Microsoft.PowerShell.Commands.WriteErrorException"
+        assert invoc_props["MyCommand"] == "Write-Error 'error stream'\n"
+        assert invoc_props["BoundParameters"] == {}
+        assert invoc_props["UnboundArguments"] == []
+        assert invoc_props["ScriptLineNumber"] == 0
+        assert invoc_props["OffsetInLine"] == 0
+        assert invoc_props["HistoryId"] == 1
+        assert invoc_props["CommandOrigin"] == "Internal"
+        assert actual.fq_error == "Microsoft.PowerShell.Commands.WriteErrorException"
         assert actual.category == 0
         assert actual.reason == "WriteErrorException"
         assert actual.target_name == ""
         assert actual.target_type == ""
-        assert actual.message == \
-            "NotSpecified: (:) [Write-Error], WriteErrorException"
+        assert actual.message == "NotSpecified: (:) [Write-Error], WriteErrorException"
         assert actual.details_message is None
         assert actual.action is None
-        assert actual.script_stacktrace == \
-            "at <ScriptBlock>, <No file>: line 5"
+        assert actual.script_stacktrace == "at <ScriptBlock>, <No file>: line 5"
         assert actual.extended_info_present
         assert actual.invocation_name == ""
         assert actual.invocation_bound_parameters == {}
@@ -380,9 +379,8 @@ class TestErrorRecord(object):
 
 
 class TestWarningRecord(object):
-
     def test_parse_warning(self):
-        xml = '''<Obj RefId="0">
+        xml = """<Obj RefId="0">
             <TN RefId="0">
                 <T>System.Management.Automation.WarningRecord</T>
                 <T>System.Management.Automation.InformationalRecord</T>
@@ -474,7 +472,7 @@ class TestWarningRecord(object):
                     </LST>
                 </Obj>
             </MS>
-        </Obj>'''
+        </Obj>"""
         serializer = Serializer()
         meta = ObjectMeta("Obj", object=WarningRecord)
         actual = serializer.deserialize(xml, meta)

--- a/tests/test_negotiate.py
+++ b/tests/test_negotiate.py
@@ -1,62 +1,55 @@
 import base64
 import re
-import requests
 import warnings
 
 import pytest
-
+import requests
 from urllib3.response import HTTPResponse
 
 from pypsrp.exceptions import AuthenticationError
 from pypsrp.negotiate import HTTPNegotiateAuth
 
-try:
-    from unittest.mock import MagicMock
-except ImportError:
-    from mock import MagicMock
-
 
 class TestTokenHelpers(object):
-
     def test_auth_supported(self):
         response = requests.Response()
-        response.headers['www-authenticate'] = "Negotiate"
+        response.headers["www-authenticate"] = "Negotiate"
         HTTPNegotiateAuth._check_auth_supported(response, "Negotiate")
 
     def test_auth_supported_multiple(self):
         response = requests.Response()
-        response.headers['www-authenticate'] = "Negotiate, CredSSP, " \
-                                               "Basic Realm='WSMan'"
+        response.headers["www-authenticate"] = "Negotiate, CredSSP, Basic Realm='WSMan'"
         HTTPNegotiateAuth._check_auth_supported(response, "Negotiate")
 
     def test_auth_not_supported(self):
         response = requests.Response()
-        response.headers['www-authenticate'] = "CredSSP"
+        response.headers["www-authenticate"] = "CredSSP"
 
-        expected = "The server did not response with one of the following authentication methods Negotiate - " \
-                   "actual: 'CredSSP'"
+        expected = (
+            "The server did not response with one of the following authentication methods Negotiate - "
+            "actual: 'CredSSP'"
+        )
         with pytest.raises(AuthenticationError, match=re.escape(expected)):
             HTTPNegotiateAuth._check_auth_supported(response, ["Negotiate"])
 
     def test_auth_not_supported_no_header(self):
         response = requests.Response()
 
-        expected = "The server did not response with one of the following authentication methods Negotiate - " \
-                   "actual: ''"
+        expected = "The server did not response with one of the following authentication methods Negotiate - actual: ''"
         with pytest.raises(AuthenticationError, match=re.escape(expected)):
             HTTPNegotiateAuth._check_auth_supported(response, ["Negotiate"])
 
     def test_set_auth_token(self):
-        request = requests.Request('GET', '')
+        request = requests.Request("GET", "")
         expected = b"Negotiate YWJj"
         HTTPNegotiateAuth._set_auth_token(request, b"abc", "Negotiate")
-        actual = request.headers['Authorization']
+        actual = request.headers["Authorization"]
         assert actual == expected
 
     def test_get_auth_token_present(self):
         auth = HTTPNegotiateAuth()
         response = requests.Response()
-        response.headers['www-authenticate'] = "Negotiate YWJj"
+        response.headers["www-authenticate"] = "Negotiate YWJj"
         expected = b"abc"
         actual = HTTPNegotiateAuth._get_auth_token(response, auth._regex)
         assert actual == expected
@@ -68,272 +61,311 @@ class TestTokenHelpers(object):
         actual = HTTPNegotiateAuth._get_auth_token(response, auth._regex)
         assert actual == expected
 
-    @pytest.mark.parametrize('header', ['Kerberos', 'Negotiate', 'NTLM'])
+    @pytest.mark.parametrize("header", ["Kerberos", "Negotiate", "NTLM"])
     def test_get_auth_token_kerberos_auth(self, header):
         auth = HTTPNegotiateAuth()
         response = requests.Response()
-        response.headers['www-authenticate'] = "%s YWJj" % header
-        expected = b'abc'
+        response.headers["www-authenticate"] = "%s YWJj" % header
+        expected = b"abc"
         actual = HTTPNegotiateAuth._get_auth_token(response, auth._regex)
         assert actual == expected
 
     def test_get_auth_token_different_auth(self):
         auth = HTTPNegotiateAuth()
         response = requests.Response()
-        response.headers['www-authenticate'] = "Fake YWJj"
+        response.headers["www-authenticate"] = "Fake YWJj"
         expected = None
         actual = HTTPNegotiateAuth._get_auth_token(response, auth._regex)
         assert actual == expected
 
 
 class TestCertificateHash(object):
-
     def test_rsa_md5(self):
-        cert_der = b'MIIDGzCCAgOgAwIBAgIQJzshhViMG5hLHIJHxa+TcTANBgkqhkiG9w0' \
-                   b'BAQQFADAVMRMwEQYDVQQDDApTRVJWRVIyMDE2MB4XDTE3MDUzMDA4MD' \
-                   b'MxNloXDTE4MDUzMDA4MjMxNlowFTETMBEGA1UEAwwKU0VSVkVSMjAxN' \
-                   b'jCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAN9N5GAzI7uq' \
-                   b'AVlI6vUqhY5+EZWCWWGRwR3FT2DEXE5++AiJxXO0i0ZfAkLu7UggtBe' \
-                   b'QwVNkaPD27EYzVUhy1iDo37BrFcLNpfjsjj8wVjaSmQmqvLvrvEh/BT' \
-                   b'C5SBgDrk2+hiMh9PrpJoB3QAMDinz5aW0rEXMKitPBBiADrczyYrliF' \
-                   b'AlEU6pTlKEKDUAeP7dKOBlDbCYvBxKnR3ddVH74I5T2SmNBq5gzkbKP' \
-                   b'nlCXdHLZSh74USu93rKDZQF8YzdTO5dcBreJDJsntyj1o49w9WCt6M7' \
-                   b'+pg6vKvE+tRbpCm7kXq5B9PDi42Nb6//MzNaMYf9V7v5MHapvVSv3+y' \
-                   b'sCAwEAAaNnMGUwDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGA' \
-                   b'QUFBwMCBggrBgEFBQcDATAVBgNVHREEDjAMggpTRVJWRVIyMDE2MB0G' \
-                   b'A1UdDgQWBBTh4L2Clr9ber6yfY3JFS3wiECL4DANBgkqhkiG9w0BAQQ' \
-                   b'FAAOCAQEA0JK/SL7SP9/nvqWp52vnsxVefTFehThle5DLzagmms/9gu' \
-                   b'oSE2I9XkQIttFMprPosaIZWt7WP42uGcZmoZOzU8kFFYJMfg9Ovyca+' \
-                   b'gnG28jDUMF1E74KrC7uynJiQJ4vPy8ne7F3XJ592LsNJmK577l42gAW' \
-                   b'u08p3TvEJFNHy2dBk/IwZp0HIPr9+JcPf7v0uL6lK930xHJHP56XLzN' \
-                   b'YG8vCMpJFR7wVZp3rXkJQUy3GxyHPJPjS8S43I9j+PoyioWIMEotq2+' \
-                   b'q0IpXU/KeNFkdGV6VPCmzhykijExOMwO6doUzIUM8orv9jYLHXYC+i6' \
-                   b'IFKSb6runxF1MAik+GCSA=='
+        cert_der = (
+            b"MIIDGzCCAgOgAwIBAgIQJzshhViMG5hLHIJHxa+TcTANBgkqhkiG9w0"
+            b"BAQQFADAVMRMwEQYDVQQDDApTRVJWRVIyMDE2MB4XDTE3MDUzMDA4MD"
+            b"MxNloXDTE4MDUzMDA4MjMxNlowFTETMBEGA1UEAwwKU0VSVkVSMjAxN"
+            b"jCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAN9N5GAzI7uq"
+            b"AVlI6vUqhY5+EZWCWWGRwR3FT2DEXE5++AiJxXO0i0ZfAkLu7UggtBe"
+            b"QwVNkaPD27EYzVUhy1iDo37BrFcLNpfjsjj8wVjaSmQmqvLvrvEh/BT"
+            b"C5SBgDrk2+hiMh9PrpJoB3QAMDinz5aW0rEXMKitPBBiADrczyYrliF"
+            b"AlEU6pTlKEKDUAeP7dKOBlDbCYvBxKnR3ddVH74I5T2SmNBq5gzkbKP"
+            b"nlCXdHLZSh74USu93rKDZQF8YzdTO5dcBreJDJsntyj1o49w9WCt6M7"
+            b"+pg6vKvE+tRbpCm7kXq5B9PDi42Nb6//MzNaMYf9V7v5MHapvVSv3+y"
+            b"sCAwEAAaNnMGUwDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGA"
+            b"QUFBwMCBggrBgEFBQcDATAVBgNVHREEDjAMggpTRVJWRVIyMDE2MB0G"
+            b"A1UdDgQWBBTh4L2Clr9ber6yfY3JFS3wiECL4DANBgkqhkiG9w0BAQQ"
+            b"FAAOCAQEA0JK/SL7SP9/nvqWp52vnsxVefTFehThle5DLzagmms/9gu"
+            b"oSE2I9XkQIttFMprPosaIZWt7WP42uGcZmoZOzU8kFFYJMfg9Ovyca+"
+            b"gnG28jDUMF1E74KrC7uynJiQJ4vPy8ne7F3XJ592LsNJmK577l42gAW"
+            b"u08p3TvEJFNHy2dBk/IwZp0HIPr9+JcPf7v0uL6lK930xHJHP56XLzN"
+            b"YG8vCMpJFR7wVZp3rXkJQUy3GxyHPJPjS8S43I9j+PoyioWIMEotq2+"
+            b"q0IpXU/KeNFkdGV6VPCmzhykijExOMwO6doUzIUM8orv9jYLHXYC+i6"
+            b"IFKSb6runxF1MAik+GCSA=="
+        )
         cert_der = base64.b64decode(cert_der)
 
-        expected = b'\x23\x34\xB8\x47\x6C\xBF\x4E\x6D\xFC\x76\x6A\x5D' \
-                   b'\x5A\x30\xD6\x64\x9C\x01\xBA\xE1\x66\x2A\x5C\x3A' \
-                   b'\x13\x02\xA9\x68\xD7\xC6\xB0\xF6'
+        expected = (
+            b"\x23\x34\xB8\x47\x6C\xBF\x4E\x6D\xFC\x76\x6A\x5D"
+            b"\x5A\x30\xD6\x64\x9C\x01\xBA\xE1\x66\x2A\x5C\x3A"
+            b"\x13\x02\xA9\x68\xD7\xC6\xB0\xF6"
+        )
         actual = HTTPNegotiateAuth._get_certificate_hash(cert_der)
         assert actual == expected
 
     def test_rsa_sha1(self):
-        cert_der = b'MIIDGzCCAgOgAwIBAgIQJg/Mf5sR55xApJRK+kabbTANBgkqhkiG9w0' \
-                   b'BAQUFADAVMRMwEQYDVQQDDApTRVJWRVIyMDE2MB4XDTE3MDUzMDA4MD' \
-                   b'MxNloXDTE4MDUzMDA4MjMxNlowFTETMBEGA1UEAwwKU0VSVkVSMjAxN' \
-                   b'jCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALPKwYikjbzL' \
-                   b'Lo6JtS6cyytdMMjSrggDoTnRUKauC5/izoYJd+2YVR5YqnluBJZpoFp' \
-                   b'hkCgFFohUOU7qUsI1SkuGnjI8RmWTrrDsSy62BrfX+AXkoPlXo6IpHz' \
-                   b'HaEPxjHJdUACpn8QVWTPmdAhwTwQkeUutrm3EOVnKPX4bafNYeAyj7/' \
-                   b'AGEplgibuXT4/ehbzGKOkRN3ds/pZuf0xc4Q2+gtXn20tQIUt7t6iwh' \
-                   b'nEWjIgopFL/hX/r5q5MpF6stc1XgIwJjEzqMp76w/HUQVqaYneU4qSG' \
-                   b'f90ANK/TQ3aDbUNtMC/ULtIfHqHIW4POuBYXaWBsqalJL2VL3YYkKTU' \
-                   b'sCAwEAAaNnMGUwDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGA' \
-                   b'QUFBwMCBggrBgEFBQcDATAVBgNVHREEDjAMggpTRVJWRVIyMDE2MB0G' \
-                   b'A1UdDgQWBBS1jgojcjPu9vqeP1uSKuiIonGwAjANBgkqhkiG9w0BAQU' \
-                   b'FAAOCAQEAKjHL6k5Dv/Zb7dvbYEZyx0wVhjHkCTpT3xstI3+TjfAFsu' \
-                   b'3zMmyFqFqzmr4pWZ/rHc3ObD4pEa24kP9hfB8nmr8oHMLebGmvkzh5h' \
-                   b'0GYc4dIH7Ky1yfQN51hi7/X5iN7jnnBoCJTTlgeBVYDOEBXhfXi3cLT' \
-                   b'u3d7nz2heyNq07gFP8iN7MfqdPZndVDYY82imLgsgar9w5d+fvnYM+k' \
-                   b'XWItNNCUH18M26Obp4Es/Qogo/E70uqkMHost2D+tww/7woXi36X3w/' \
-                   b'D2yBDyrJMJKZLmDgfpNIeCimncTOzi2IhzqJiOY/4XPsVN/Xqv0/dzG' \
-                   b'TDdI11kPLq4EiwxvPanCg=='
+        cert_der = (
+            b"MIIDGzCCAgOgAwIBAgIQJg/Mf5sR55xApJRK+kabbTANBgkqhkiG9w0"
+            b"BAQUFADAVMRMwEQYDVQQDDApTRVJWRVIyMDE2MB4XDTE3MDUzMDA4MD"
+            b"MxNloXDTE4MDUzMDA4MjMxNlowFTETMBEGA1UEAwwKU0VSVkVSMjAxN"
+            b"jCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALPKwYikjbzL"
+            b"Lo6JtS6cyytdMMjSrggDoTnRUKauC5/izoYJd+2YVR5YqnluBJZpoFp"
+            b"hkCgFFohUOU7qUsI1SkuGnjI8RmWTrrDsSy62BrfX+AXkoPlXo6IpHz"
+            b"HaEPxjHJdUACpn8QVWTPmdAhwTwQkeUutrm3EOVnKPX4bafNYeAyj7/"
+            b"AGEplgibuXT4/ehbzGKOkRN3ds/pZuf0xc4Q2+gtXn20tQIUt7t6iwh"
+            b"nEWjIgopFL/hX/r5q5MpF6stc1XgIwJjEzqMp76w/HUQVqaYneU4qSG"
+            b"f90ANK/TQ3aDbUNtMC/ULtIfHqHIW4POuBYXaWBsqalJL2VL3YYkKTU"
+            b"sCAwEAAaNnMGUwDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGA"
+            b"QUFBwMCBggrBgEFBQcDATAVBgNVHREEDjAMggpTRVJWRVIyMDE2MB0G"
+            b"A1UdDgQWBBS1jgojcjPu9vqeP1uSKuiIonGwAjANBgkqhkiG9w0BAQU"
+            b"FAAOCAQEAKjHL6k5Dv/Zb7dvbYEZyx0wVhjHkCTpT3xstI3+TjfAFsu"
+            b"3zMmyFqFqzmr4pWZ/rHc3ObD4pEa24kP9hfB8nmr8oHMLebGmvkzh5h"
+            b"0GYc4dIH7Ky1yfQN51hi7/X5iN7jnnBoCJTTlgeBVYDOEBXhfXi3cLT"
+            b"u3d7nz2heyNq07gFP8iN7MfqdPZndVDYY82imLgsgar9w5d+fvnYM+k"
+            b"XWItNNCUH18M26Obp4Es/Qogo/E70uqkMHost2D+tww/7woXi36X3w/"
+            b"D2yBDyrJMJKZLmDgfpNIeCimncTOzi2IhzqJiOY/4XPsVN/Xqv0/dzG"
+            b"TDdI11kPLq4EiwxvPanCg=="
+        )
         cert_der = base64.b64decode(cert_der)
 
-        expected = b'\x14\xCF\xE8\xE4\xB3\x32\xB2\x0A\x34\x3F\xC8\x40' \
-                   b'\xB1\x8F\x9F\x6F\x78\x92\x6A\xFE\x7E\xC3\xE7\xB8' \
-                   b'\xE2\x89\x69\x61\x9B\x1E\x8F\x3E'
+        expected = (
+            b"\x14\xCF\xE8\xE4\xB3\x32\xB2\x0A\x34\x3F\xC8\x40"
+            b"\xB1\x8F\x9F\x6F\x78\x92\x6A\xFE\x7E\xC3\xE7\xB8"
+            b"\xE2\x89\x69\x61\x9B\x1E\x8F\x3E"
+        )
         actual = HTTPNegotiateAuth._get_certificate_hash(cert_der)
         assert actual == expected
 
     def test_rsa_sha256(self):
-        cert_der = b'MIIDGzCCAgOgAwIBAgIQWkeAtqoFg6pNWF7xC4YXhTANBgkqhkiG9w0' \
-                   b'BAQsFADAVMRMwEQYDVQQDDApTRVJWRVIyMDE2MB4XDTE3MDUyNzA5MD' \
-                   b'I0NFoXDTE4MDUyNzA5MjI0NFowFTETMBEGA1UEAwwKU0VSVkVSMjAxN' \
-                   b'jCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALIPKM5uykFy' \
-                   b'NmVoLyvPSXGk15ZDqjYi3AbUxVFwCkVImqhefLATit3PkTUYFtAT+TC' \
-                   b'AwK2E4lOu1XHM+Tmp2KIOnq2oUR8qMEvfxYThEf1MHxkctFljFssZ9N' \
-                   b'vASDD4lzw8r0Bhl+E5PhR22Eu1Wago5bvIldojkwG+WBxPQv3ZR546L' \
-                   b'MUZNaBXC0RhuGj5w83lbVz75qM98wvv1ekfZYAP7lrVyHxqCTPDomEU' \
-                   b'I45tQQZHCZl5nRx1fPCyyYfcfqvFlLWD4Q3PZAbnw6mi0MiWJbGYKME' \
-                   b'1XGicjqyn/zM9XKA1t/JzChS2bxf6rsyA9I7ibdRHUxsm1JgKry2jfW' \
-                   b'0CAwEAAaNnMGUwDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGA' \
-                   b'QUFBwMCBggrBgEFBQcDATAVBgNVHREEDjAMggpTRVJWRVIyMDE2MB0G' \
-                   b'A1UdDgQWBBQabLGWg1sn7AXPwYPyfE0ER921ZDANBgkqhkiG9w0BAQs' \
-                   b'FAAOCAQEAnRohyl6ZmOsTWCtxOJx5A8yr//NweXKwWWmFQXRmCb4bMC' \
-                   b'xhD4zqLDf5P6RotGV0I/SHvqz+pAtJuwmr+iyAF6WTzo3164LCfnQEu' \
-                   b'psfrrfMkf3txgDwQkA0oPAw3HEwOnR+tzprw3Yg9x6UoZEhi4XqP9AX' \
-                   b'R49jU92KrNXJcPlz5MbkzNo5t9nr2f8q39b5HBjaiBJxzdM1hxqsbfD' \
-                   b'KirTYbkUgPlVOo/NDmopPPb8IX8ubj/XETZG2jixD0zahgcZ1vdr/iZ' \
-                   b'+50WSXKN2TAKBO2fwoK+2/zIWrGRxJTARfQdF+fGKuj+AERIFNh88HW' \
-                   b'xSDYjHQAaFMcfdUpa9GGQ=='
+        cert_der = (
+            b"MIIDGzCCAgOgAwIBAgIQWkeAtqoFg6pNWF7xC4YXhTANBgkqhkiG9w0"
+            b"BAQsFADAVMRMwEQYDVQQDDApTRVJWRVIyMDE2MB4XDTE3MDUyNzA5MD"
+            b"I0NFoXDTE4MDUyNzA5MjI0NFowFTETMBEGA1UEAwwKU0VSVkVSMjAxN"
+            b"jCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALIPKM5uykFy"
+            b"NmVoLyvPSXGk15ZDqjYi3AbUxVFwCkVImqhefLATit3PkTUYFtAT+TC"
+            b"AwK2E4lOu1XHM+Tmp2KIOnq2oUR8qMEvfxYThEf1MHxkctFljFssZ9N"
+            b"vASDD4lzw8r0Bhl+E5PhR22Eu1Wago5bvIldojkwG+WBxPQv3ZR546L"
+            b"MUZNaBXC0RhuGj5w83lbVz75qM98wvv1ekfZYAP7lrVyHxqCTPDomEU"
+            b"I45tQQZHCZl5nRx1fPCyyYfcfqvFlLWD4Q3PZAbnw6mi0MiWJbGYKME"
+            b"1XGicjqyn/zM9XKA1t/JzChS2bxf6rsyA9I7ibdRHUxsm1JgKry2jfW"
+            b"0CAwEAAaNnMGUwDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGA"
+            b"QUFBwMCBggrBgEFBQcDATAVBgNVHREEDjAMggpTRVJWRVIyMDE2MB0G"
+            b"A1UdDgQWBBQabLGWg1sn7AXPwYPyfE0ER921ZDANBgkqhkiG9w0BAQs"
+            b"FAAOCAQEAnRohyl6ZmOsTWCtxOJx5A8yr//NweXKwWWmFQXRmCb4bMC"
+            b"xhD4zqLDf5P6RotGV0I/SHvqz+pAtJuwmr+iyAF6WTzo3164LCfnQEu"
+            b"psfrrfMkf3txgDwQkA0oPAw3HEwOnR+tzprw3Yg9x6UoZEhi4XqP9AX"
+            b"R49jU92KrNXJcPlz5MbkzNo5t9nr2f8q39b5HBjaiBJxzdM1hxqsbfD"
+            b"KirTYbkUgPlVOo/NDmopPPb8IX8ubj/XETZG2jixD0zahgcZ1vdr/iZ"
+            b"+50WSXKN2TAKBO2fwoK+2/zIWrGRxJTARfQdF+fGKuj+AERIFNh88HW"
+            b"xSDYjHQAaFMcfdUpa9GGQ=="
+        )
         cert_der = base64.b64decode(cert_der)
 
-        expected = b'\x99\x6F\x3E\xEA\x81\x2C\x18\x70\xE3\x05\x49\xFF' \
-                   b'\x9B\x86\xCD\x87\xA8\x90\xB6\xD8\xDF\xDF\x4A\x81' \
-                   b'\xBE\xF9\x67\x59\x70\xDA\xDB\x26'
+        expected = (
+            b"\x99\x6F\x3E\xEA\x81\x2C\x18\x70\xE3\x05\x49\xFF"
+            b"\x9B\x86\xCD\x87\xA8\x90\xB6\xD8\xDF\xDF\x4A\x81"
+            b"\xBE\xF9\x67\x59\x70\xDA\xDB\x26"
+        )
         actual = HTTPNegotiateAuth._get_certificate_hash(cert_der)
         assert actual == expected
 
     def test_rsa_sha384(self):
-        cert_der = b'MIIDGzCCAgOgAwIBAgIQEmj1prSSQYRL2zYBEjsm5jANBgkqhkiG9w0' \
-                   b'BAQwFADAVMRMwEQYDVQQDDApTRVJWRVIyMDE2MB4XDTE3MDUzMDA4MD' \
-                   b'MxN1oXDTE4MDUzMDA4MjMxN1owFTETMBEGA1UEAwwKU0VSVkVSMjAxN' \
-                   b'jCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKsK5NvHi4xO' \
-                   b'081fRLMmPqKsKaHvXgPRykLA0SmKxpGJHfTAZzxojHVeVwOm87IvQj2' \
-                   b'JUh/yrRwSi5Oqrvqx29l2IC/qQt2xkAQsO51/EWkMQ5OSJsl1MN3NXW' \
-                   b'eRTKVoUuJzBs8XLmeraxQcBPyyLhq+WpMl/Q4ZDn1FrUEZfxV0POXgU' \
-                   b'dI3ApuQNRtJOb6iteBIoQyMlnof0RswBUnkiWCA/+/nzR0j33j47IfL' \
-                   b'nkmU4RtqkBlO13f6+e1GZ4lEcQVI2yZq4Zgu5VVGAFU2lQZ3aEVMTu9' \
-                   b'8HEqD6heyNp2on5G/K/DCrGWYCBiASjnX3wiSz0BYv8f3HhCgIyVKhJ' \
-                   b'8CAwEAAaNnMGUwDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGA' \
-                   b'QUFBwMCBggrBgEFBQcDATAVBgNVHREEDjAMggpTRVJWRVIyMDE2MB0G' \
-                   b'A1UdDgQWBBQS/SI61S2UE8xwSgHxbkCTpZXo4TANBgkqhkiG9w0BAQw' \
-                   b'FAAOCAQEAMVV/WMXd9w4jtDfSrIsKaWKGtHtiMPpAJibXmSakBRwLOn' \
-                   b'5ZGXL2bWI/Ac2J2Y7bSzs1im2ifwmEqwzzqnpVKShIkZmtij0LS0SEr' \
-                   b'6Fw5IrK8tD6SH+lMMXUTvp4/lLQlgRCwOWxry/YhQSnuprx8IfSPvil' \
-                   b'kwZ0Ysim4Aa+X5ojlhHpWB53edX+lFrmR1YWValBnQ5DvnDyFyLR6II' \
-                   b'Ialp4vmkzI9e3/eOgSArksizAhpXpC9dxQBiHXdhredN0X+1BVzbgzV' \
-                   b'hQBEwgnAIPa+B68oDILaV0V8hvxrP6jFM4IrKoGS1cq0B+Ns0zkG7ZA' \
-                   b'2Q0W+3nVwSxIr6bd6hw7g=='
+        cert_der = (
+            b"MIIDGzCCAgOgAwIBAgIQEmj1prSSQYRL2zYBEjsm5jANBgkqhkiG9w0"
+            b"BAQwFADAVMRMwEQYDVQQDDApTRVJWRVIyMDE2MB4XDTE3MDUzMDA4MD"
+            b"MxN1oXDTE4MDUzMDA4MjMxN1owFTETMBEGA1UEAwwKU0VSVkVSMjAxN"
+            b"jCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKsK5NvHi4xO"
+            b"081fRLMmPqKsKaHvXgPRykLA0SmKxpGJHfTAZzxojHVeVwOm87IvQj2"
+            b"JUh/yrRwSi5Oqrvqx29l2IC/qQt2xkAQsO51/EWkMQ5OSJsl1MN3NXW"
+            b"eRTKVoUuJzBs8XLmeraxQcBPyyLhq+WpMl/Q4ZDn1FrUEZfxV0POXgU"
+            b"dI3ApuQNRtJOb6iteBIoQyMlnof0RswBUnkiWCA/+/nzR0j33j47IfL"
+            b"nkmU4RtqkBlO13f6+e1GZ4lEcQVI2yZq4Zgu5VVGAFU2lQZ3aEVMTu9"
+            b"8HEqD6heyNp2on5G/K/DCrGWYCBiASjnX3wiSz0BYv8f3HhCgIyVKhJ"
+            b"8CAwEAAaNnMGUwDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGA"
+            b"QUFBwMCBggrBgEFBQcDATAVBgNVHREEDjAMggpTRVJWRVIyMDE2MB0G"
+            b"A1UdDgQWBBQS/SI61S2UE8xwSgHxbkCTpZXo4TANBgkqhkiG9w0BAQw"
+            b"FAAOCAQEAMVV/WMXd9w4jtDfSrIsKaWKGtHtiMPpAJibXmSakBRwLOn"
+            b"5ZGXL2bWI/Ac2J2Y7bSzs1im2ifwmEqwzzqnpVKShIkZmtij0LS0SEr"
+            b"6Fw5IrK8tD6SH+lMMXUTvp4/lLQlgRCwOWxry/YhQSnuprx8IfSPvil"
+            b"kwZ0Ysim4Aa+X5ojlhHpWB53edX+lFrmR1YWValBnQ5DvnDyFyLR6II"
+            b"Ialp4vmkzI9e3/eOgSArksizAhpXpC9dxQBiHXdhredN0X+1BVzbgzV"
+            b"hQBEwgnAIPa+B68oDILaV0V8hvxrP6jFM4IrKoGS1cq0B+Ns0zkG7ZA"
+            b"2Q0W+3nVwSxIr6bd6hw7g=="
+        )
         cert_der = base64.b64decode(cert_der)
 
-        expected = b'\x34\xF3\x03\xC9\x95\x28\x6F\x4B\x21\x4A\x9B\xA6' \
-                   b'\x43\x5B\x69\xB5\x1E\xCF\x37\x58\xEA\xBC\x2A\x14' \
-                   b'\xD7\xA4\x3F\xD2\x37\xDC\x2B\x1A\x1A\xD9\x11\x1C' \
-                   b'\x5C\x96\x5E\x10\x75\x07\xCB\x41\x98\xC0\x9F\xEC'
+        expected = (
+            b"\x34\xF3\x03\xC9\x95\x28\x6F\x4B\x21\x4A\x9B\xA6"
+            b"\x43\x5B\x69\xB5\x1E\xCF\x37\x58\xEA\xBC\x2A\x14"
+            b"\xD7\xA4\x3F\xD2\x37\xDC\x2B\x1A\x1A\xD9\x11\x1C"
+            b"\x5C\x96\x5E\x10\x75\x07\xCB\x41\x98\xC0\x9F\xEC"
+        )
         actual = HTTPNegotiateAuth._get_certificate_hash(cert_der)
         assert actual == expected
 
     def test_rsa_sha512(self):
-        cert_der = b'MIIDGzCCAgOgAwIBAgIQUDHcKGevZohJV+TkIIYC1DANBgkqhkiG9w0' \
-                   b'BAQ0FADAVMRMwEQYDVQQDDApTRVJWRVIyMDE2MB4XDTE3MDUzMDA4MD' \
-                   b'MxN1oXDTE4MDUzMDA4MjMxN1owFTETMBEGA1UEAwwKU0VSVkVSMjAxN' \
-                   b'jCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKr9bo/XXvHt' \
-                   b'D6Qnhb1wyLg9lDQxxe/enH49LQihtVTZMwGf2010h81QrRUe/bkHTvw' \
-                   b'K22s2lqj3fUpGxtEbYFWLAHxv6IFnIKd+Zi1zaCPGfas9ekqCSj3vZQ' \
-                   b'j7lCJVGUGuuqnSDvsed6g2Pz/g6mJUa+TzjxN+8wU5oj5YVUK+aing1' \
-                   b'zPSA2MDCfx3+YzjxVwNoGixOz6Yx9ijT4pUsAYQAf1o9R+6W1/IpGgu' \
-                   b'oax714QILT9heqIowwlHzlUZc1UAYs0/JA4CbDZaw9hlJyzMqe/aE46' \
-                   b'efqPDOpO3vCpOSRcSyzh02WijPvEEaPejQRWg8RX93othZ615MT7dqp' \
-                   b'ECAwEAAaNnMGUwDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGA' \
-                   b'QUFBwMCBggrBgEFBQcDATAVBgNVHREEDjAMggpTRVJWRVIyMDE2MB0G' \
-                   b'A1UdDgQWBBTgod3R6vejt6kOASAApA19xIG6kTANBgkqhkiG9w0BAQ0' \
-                   b'FAAOCAQEAVfz0okK2bh3OQE8cWNbJ5PjJRSAJEqVUvYaTlS0Nqkyuaj' \
-                   b'gicP3hb/pF8FvaVaB6r7LqgBxyW5NNL1xwdNLt60M2zaULL6Fhm1vzM' \
-                   b'sSMc2ynkyN4++ODwii674YcQAnkUh+ZGIx+CTdZBWJfVM9dZb7QjgBT' \
-                   b'nVukeFwN2EOOBSpiQSBpcoeJEEAq9csDVRhEfcB8Wtz7TTItgOVsilY' \
-                   b'dQY56ON5XszjCki6UA3GwdQbBEHjWF2WERqXWrojrSSNOYDvxM5mrEx' \
-                   b'sG1npzUTsaIr9w8ty1beh/2aToCMREvpiPFOXnVV/ovHMU1lFQTNeQ0' \
-                   b'OI7elR0nJ0peai30eMpQQ=='
+        cert_der = (
+            b"MIIDGzCCAgOgAwIBAgIQUDHcKGevZohJV+TkIIYC1DANBgkqhkiG9w0"
+            b"BAQ0FADAVMRMwEQYDVQQDDApTRVJWRVIyMDE2MB4XDTE3MDUzMDA4MD"
+            b"MxN1oXDTE4MDUzMDA4MjMxN1owFTETMBEGA1UEAwwKU0VSVkVSMjAxN"
+            b"jCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKr9bo/XXvHt"
+            b"D6Qnhb1wyLg9lDQxxe/enH49LQihtVTZMwGf2010h81QrRUe/bkHTvw"
+            b"K22s2lqj3fUpGxtEbYFWLAHxv6IFnIKd+Zi1zaCPGfas9ekqCSj3vZQ"
+            b"j7lCJVGUGuuqnSDvsed6g2Pz/g6mJUa+TzjxN+8wU5oj5YVUK+aing1"
+            b"zPSA2MDCfx3+YzjxVwNoGixOz6Yx9ijT4pUsAYQAf1o9R+6W1/IpGgu"
+            b"oax714QILT9heqIowwlHzlUZc1UAYs0/JA4CbDZaw9hlJyzMqe/aE46"
+            b"efqPDOpO3vCpOSRcSyzh02WijPvEEaPejQRWg8RX93othZ615MT7dqp"
+            b"ECAwEAAaNnMGUwDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGA"
+            b"QUFBwMCBggrBgEFBQcDATAVBgNVHREEDjAMggpTRVJWRVIyMDE2MB0G"
+            b"A1UdDgQWBBTgod3R6vejt6kOASAApA19xIG6kTANBgkqhkiG9w0BAQ0"
+            b"FAAOCAQEAVfz0okK2bh3OQE8cWNbJ5PjJRSAJEqVUvYaTlS0Nqkyuaj"
+            b"gicP3hb/pF8FvaVaB6r7LqgBxyW5NNL1xwdNLt60M2zaULL6Fhm1vzM"
+            b"sSMc2ynkyN4++ODwii674YcQAnkUh+ZGIx+CTdZBWJfVM9dZb7QjgBT"
+            b"nVukeFwN2EOOBSpiQSBpcoeJEEAq9csDVRhEfcB8Wtz7TTItgOVsilY"
+            b"dQY56ON5XszjCki6UA3GwdQbBEHjWF2WERqXWrojrSSNOYDvxM5mrEx"
+            b"sG1npzUTsaIr9w8ty1beh/2aToCMREvpiPFOXnVV/ovHMU1lFQTNeQ0"
+            b"OI7elR0nJ0peai30eMpQQ=="
+        )
         cert_der = base64.b64decode(cert_der)
 
-        expected = b'\x55\x6E\x1C\x17\x84\xE3\xB9\x57\x37\x0B\x7F\x54' \
-                   b'\x4F\x62\xC5\x33\xCB\x2C\xA5\xC1\xDA\xE0\x70\x6F' \
-                   b'\xAE\xF0\x05\x44\xE1\xAD\x2B\x76\xFF\x25\xCF\xBE' \
-                   b'\x69\xB1\xC4\xE6\x30\xC3\xBB\x02\x07\xDF\x11\x31' \
-                   b'\x4C\x67\x38\xBC\xAE\xD7\xE0\x71\xD7\xBF\xBF\x2C' \
-                   b'\x9D\xFA\xB8\x5D'
+        expected = (
+            b"\x55\x6E\x1C\x17\x84\xE3\xB9\x57\x37\x0B\x7F\x54"
+            b"\x4F\x62\xC5\x33\xCB\x2C\xA5\xC1\xDA\xE0\x70\x6F"
+            b"\xAE\xF0\x05\x44\xE1\xAD\x2B\x76\xFF\x25\xCF\xBE"
+            b"\x69\xB1\xC4\xE6\x30\xC3\xBB\x02\x07\xDF\x11\x31"
+            b"\x4C\x67\x38\xBC\xAE\xD7\xE0\x71\xD7\xBF\xBF\x2C"
+            b"\x9D\xFA\xB8\x5D"
+        )
         actual = HTTPNegotiateAuth._get_certificate_hash(cert_der)
         assert actual == expected
 
     def test_ecdsa_sha1(self):
-        cert_der = b'MIIBjjCCATSgAwIBAgIQRCJw7nbtvJ5F8wikRmwgizAJBgcqhkjOPQQ' \
-                   b'BMBUxEzARBgNVBAMMClNFUlZFUjIwMTYwHhcNMTcwNTMwMDgwMzE3Wh' \
-                   b'cNMTgwNTMwMDgyMzE3WjAVMRMwEQYDVQQDDApTRVJWRVIyMDE2MFkwE' \
-                   b'wYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEk3fOh178kRglmnPKe9K/mbgi' \
-                   b'gf8YgNq62rF2EpfzpyQY0eGw4xnmKDG73aZ+ATSlV2IybxiUVsKyMUn' \
-                   b'LhPfvmaNnMGUwDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGAQ' \
-                   b'UFBwMCBggrBgEFBQcDATAVBgNVHREEDjAMggpTRVJWRVIyMDE2MB0GA' \
-                   b'1UdDgQWBBQSK8qwmiQmyAWWya3FxQDj9wqQAzAJBgcqhkjOPQQBA0kA' \
-                   b'MEYCIQCiOsP56Iqo+cHRvCp2toj65Mgxo/PQY1tn+S3WH4RJFQIhAJe' \
-                   b'gGQuaPWg6aCWV+2+6pNCNMdg/Nix+mMOJ88qCBNHi'
+        cert_der = (
+            b"MIIBjjCCATSgAwIBAgIQRCJw7nbtvJ5F8wikRmwgizAJBgcqhkjOPQQ"
+            b"BMBUxEzARBgNVBAMMClNFUlZFUjIwMTYwHhcNMTcwNTMwMDgwMzE3Wh"
+            b"cNMTgwNTMwMDgyMzE3WjAVMRMwEQYDVQQDDApTRVJWRVIyMDE2MFkwE"
+            b"wYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEk3fOh178kRglmnPKe9K/mbgi"
+            b"gf8YgNq62rF2EpfzpyQY0eGw4xnmKDG73aZ+ATSlV2IybxiUVsKyMUn"
+            b"LhPfvmaNnMGUwDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGAQ"
+            b"UFBwMCBggrBgEFBQcDATAVBgNVHREEDjAMggpTRVJWRVIyMDE2MB0GA"
+            b"1UdDgQWBBQSK8qwmiQmyAWWya3FxQDj9wqQAzAJBgcqhkjOPQQBA0kA"
+            b"MEYCIQCiOsP56Iqo+cHRvCp2toj65Mgxo/PQY1tn+S3WH4RJFQIhAJe"
+            b"gGQuaPWg6aCWV+2+6pNCNMdg/Nix+mMOJ88qCBNHi"
+        )
         cert_der = base64.b64decode(cert_der)
 
-        expected = b'\x1E\xC9\xAD\x46\xDE\xE9\x34\x0E\x45\x03\xCF\xFD' \
-                   b'\xB5\xCD\x81\x0C\xB2\x6B\x77\x8F\x46\xBE\x95\xD5' \
-                   b'\xEA\xF9\x99\xDC\xB1\xC4\x5E\xDA'
+        expected = (
+            b"\x1E\xC9\xAD\x46\xDE\xE9\x34\x0E\x45\x03\xCF\xFD"
+            b"\xB5\xCD\x81\x0C\xB2\x6B\x77\x8F\x46\xBE\x95\xD5"
+            b"\xEA\xF9\x99\xDC\xB1\xC4\x5E\xDA"
+        )
         actual = HTTPNegotiateAuth._get_certificate_hash(cert_der)
         assert actual == expected
 
     def test_ecdsa_sha256(self):
-        cert_der = b'MIIBjzCCATWgAwIBAgIQeNQTxkMgq4BF9tKogIGXUTAKBggqhkjOPQQ' \
-                   b'DAjAVMRMwEQYDVQQDDApTRVJWRVIyMDE2MB4XDTE3MDUzMDA4MDMxN1' \
-                   b'oXDTE4MDUzMDA4MjMxN1owFTETMBEGA1UEAwwKU0VSVkVSMjAxNjBZM' \
-                   b'BMGByqGSM49AgEGCCqGSM49AwEHA0IABDAfXTLOaC3ElgErlgk2tBlM' \
-                   b'wf9XmGlGBw4vBtMJap1hAqbsdxFm6rhK3QU8PFFpv8Z/AtRG7ba3UwQ' \
-                   b'prkssClejZzBlMA4GA1UdDwEB/wQEAwIFoDAdBgNVHSUEFjAUBggrBg' \
-                   b'EFBQcDAgYIKwYBBQUHAwEwFQYDVR0RBA4wDIIKU0VSVkVSMjAxNjAdB' \
-                   b'gNVHQ4EFgQUnFDE8824TYAiBeX4fghEEg33UgYwCgYIKoZIzj0EAwID' \
-                   b'SAAwRQIhAK3rXA4/0i6nm/U7bi6y618Ci2Is8++M3tYIXnEsA7zSAiA' \
-                   b'w2s6bJoI+D7Xaey0Hp0gkks9z55y976keIEI+n3qkzw=='
+        cert_der = (
+            b"MIIBjzCCATWgAwIBAgIQeNQTxkMgq4BF9tKogIGXUTAKBggqhkjOPQQ"
+            b"DAjAVMRMwEQYDVQQDDApTRVJWRVIyMDE2MB4XDTE3MDUzMDA4MDMxN1"
+            b"oXDTE4MDUzMDA4MjMxN1owFTETMBEGA1UEAwwKU0VSVkVSMjAxNjBZM"
+            b"BMGByqGSM49AgEGCCqGSM49AwEHA0IABDAfXTLOaC3ElgErlgk2tBlM"
+            b"wf9XmGlGBw4vBtMJap1hAqbsdxFm6rhK3QU8PFFpv8Z/AtRG7ba3UwQ"
+            b"prkssClejZzBlMA4GA1UdDwEB/wQEAwIFoDAdBgNVHSUEFjAUBggrBg"
+            b"EFBQcDAgYIKwYBBQUHAwEwFQYDVR0RBA4wDIIKU0VSVkVSMjAxNjAdB"
+            b"gNVHQ4EFgQUnFDE8824TYAiBeX4fghEEg33UgYwCgYIKoZIzj0EAwID"
+            b"SAAwRQIhAK3rXA4/0i6nm/U7bi6y618Ci2Is8++M3tYIXnEsA7zSAiA"
+            b"w2s6bJoI+D7Xaey0Hp0gkks9z55y976keIEI+n3qkzw=="
+        )
         cert_der = base64.b64decode(cert_der)
 
-        expected = b'\xFE\xCF\x1B\x25\x85\x44\x99\x90\xD9\xE3\xB2\xC9' \
-                   b'\x2D\x3F\x59\x7E\xC8\x35\x4E\x12\x4E\xDA\x75\x1D' \
-                   b'\x94\x83\x7C\x2C\x89\xA2\xC1\x55'
+        expected = (
+            b"\xFE\xCF\x1B\x25\x85\x44\x99\x90\xD9\xE3\xB2\xC9"
+            b"\x2D\x3F\x59\x7E\xC8\x35\x4E\x12\x4E\xDA\x75\x1D"
+            b"\x94\x83\x7C\x2C\x89\xA2\xC1\x55"
+        )
         actual = HTTPNegotiateAuth._get_certificate_hash(cert_der)
         assert actual == expected
 
     def test_ecdsa_sha384(self):
-        cert_der = b'MIIBjzCCATWgAwIBAgIQcO3/jALdQ6BOAoaoseLSCjAKBggqhkjOPQQ' \
-                   b'DAzAVMRMwEQYDVQQDDApTRVJWRVIyMDE2MB4XDTE3MDUzMDA4MDMxOF' \
-                   b'oXDTE4MDUzMDA4MjMxOFowFTETMBEGA1UEAwwKU0VSVkVSMjAxNjBZM' \
-                   b'BMGByqGSM49AgEGCCqGSM49AwEHA0IABJLjZH274heB/8PhmhWWCIVQ' \
-                   b'Wle1hBZEN3Tk2yWSKaz9pz1bjwb9t79lVpQE9tvGL0zP9AqJYHcVOO9' \
-                   b'YG9trqfejZzBlMA4GA1UdDwEB/wQEAwIFoDAdBgNVHSUEFjAUBggrBg' \
-                   b'EFBQcDAgYIKwYBBQUHAwEwFQYDVR0RBA4wDIIKU0VSVkVSMjAxNjAdB' \
-                   b'gNVHQ4EFgQUkRajoFr8qZ/8L8rKB3zGiGolDygwCgYIKoZIzj0EAwMD' \
-                   b'SAAwRQIgfi8dAxXljCMSvngtDtagGCTGBs7Xxh8Z3WX6ZwJZsHYCIQC' \
-                   b'D4iNReh1afXKYC0ipjXWAIkiihnEEycCIQMbkMNst7A=='
+        cert_der = (
+            b"MIIBjzCCATWgAwIBAgIQcO3/jALdQ6BOAoaoseLSCjAKBggqhkjOPQQ"
+            b"DAzAVMRMwEQYDVQQDDApTRVJWRVIyMDE2MB4XDTE3MDUzMDA4MDMxOF"
+            b"oXDTE4MDUzMDA4MjMxOFowFTETMBEGA1UEAwwKU0VSVkVSMjAxNjBZM"
+            b"BMGByqGSM49AgEGCCqGSM49AwEHA0IABJLjZH274heB/8PhmhWWCIVQ"
+            b"Wle1hBZEN3Tk2yWSKaz9pz1bjwb9t79lVpQE9tvGL0zP9AqJYHcVOO9"
+            b"YG9trqfejZzBlMA4GA1UdDwEB/wQEAwIFoDAdBgNVHSUEFjAUBggrBg"
+            b"EFBQcDAgYIKwYBBQUHAwEwFQYDVR0RBA4wDIIKU0VSVkVSMjAxNjAdB"
+            b"gNVHQ4EFgQUkRajoFr8qZ/8L8rKB3zGiGolDygwCgYIKoZIzj0EAwMD"
+            b"SAAwRQIgfi8dAxXljCMSvngtDtagGCTGBs7Xxh8Z3WX6ZwJZsHYCIQC"
+            b"D4iNReh1afXKYC0ipjXWAIkiihnEEycCIQMbkMNst7A=="
+        )
         cert_der = base64.b64decode(cert_der)
 
-        expected = b'\xD2\x98\x7A\xD8\xF2\x0E\x83\x16\xA8\x31\x26\x1B' \
-                   b'\x74\xEF\x7B\x3E\x55\x15\x5D\x09\x22\xE0\x7F\xFE' \
-                   b'\x54\x62\x08\x06\x98\x2B\x68\xA7\x3A\x5E\x3C\x47' \
-                   b'\x8B\xAA\x5E\x77\x14\x13\x5C\xB2\x6D\x98\x07\x49'
+        expected = (
+            b"\xD2\x98\x7A\xD8\xF2\x0E\x83\x16\xA8\x31\x26\x1B"
+            b"\x74\xEF\x7B\x3E\x55\x15\x5D\x09\x22\xE0\x7F\xFE"
+            b"\x54\x62\x08\x06\x98\x2B\x68\xA7\x3A\x5E\x3C\x47"
+            b"\x8B\xAA\x5E\x77\x14\x13\x5C\xB2\x6D\x98\x07\x49"
+        )
         actual = HTTPNegotiateAuth._get_certificate_hash(cert_der)
         assert actual == expected
 
     def test_ecdsa_sha512(self):
-        cert_der = b'MIIBjjCCATWgAwIBAgIQHVj2AGEwd6pOOSbcf0skQDAKBggqhkjOPQQ' \
-                   b'DBDAVMRMwEQYDVQQDDApTRVJWRVIyMDE2MB4XDTE3MDUzMDA3NTUzOV' \
-                   b'oXDTE4MDUzMDA4MTUzOVowFTETMBEGA1UEAwwKU0VSVkVSMjAxNjBZM' \
-                   b'BMGByqGSM49AgEGCCqGSM49AwEHA0IABL8d9S++MFpfzeH8B3vG/PjA' \
-                   b'AWg8tGJVgsMw9nR+OfC9ltbTUwhB+yPk3JPcfW/bqsyeUgq4//LhaSp' \
-                   b'lOWFNaNqjZzBlMA4GA1UdDwEB/wQEAwIFoDAdBgNVHSUEFjAUBggrBg' \
-                   b'EFBQcDAgYIKwYBBQUHAwEwFQYDVR0RBA4wDIIKU0VSVkVSMjAxNjAdB' \
-                   b'gNVHQ4EFgQUKUkCgLlxoeai0EtQrZth1/BSc5kwCgYIKoZIzj0EAwQD' \
-                   b'RwAwRAIgRrV7CLpDG7KueyFA3ZDced9dPOcv2Eydx/hgrfxYEcYCIBQ' \
-                   b'D35JvzmqU05kSFV5eTvkhkaDObd7V55vokhm31+Li'
+        cert_der = (
+            b"MIIBjjCCATWgAwIBAgIQHVj2AGEwd6pOOSbcf0skQDAKBggqhkjOPQQ"
+            b"DBDAVMRMwEQYDVQQDDApTRVJWRVIyMDE2MB4XDTE3MDUzMDA3NTUzOV"
+            b"oXDTE4MDUzMDA4MTUzOVowFTETMBEGA1UEAwwKU0VSVkVSMjAxNjBZM"
+            b"BMGByqGSM49AgEGCCqGSM49AwEHA0IABL8d9S++MFpfzeH8B3vG/PjA"
+            b"AWg8tGJVgsMw9nR+OfC9ltbTUwhB+yPk3JPcfW/bqsyeUgq4//LhaSp"
+            b"lOWFNaNqjZzBlMA4GA1UdDwEB/wQEAwIFoDAdBgNVHSUEFjAUBggrBg"
+            b"EFBQcDAgYIKwYBBQUHAwEwFQYDVR0RBA4wDIIKU0VSVkVSMjAxNjAdB"
+            b"gNVHQ4EFgQUKUkCgLlxoeai0EtQrZth1/BSc5kwCgYIKoZIzj0EAwQD"
+            b"RwAwRAIgRrV7CLpDG7KueyFA3ZDced9dPOcv2Eydx/hgrfxYEcYCIBQ"
+            b"D35JvzmqU05kSFV5eTvkhkaDObd7V55vokhm31+Li"
+        )
         cert_der = base64.b64decode(cert_der)
 
-        expected = b'\xE5\xCB\x68\xB2\xF8\x43\xD6\x3B\xF4\x0B\xCB\x20' \
-                   b'\x07\x60\x8F\x81\x97\x61\x83\x92\x78\x3F\x23\x30' \
-                   b'\xE5\xEF\x19\xA5\xBD\x8F\x0B\x2F\xAA\xC8\x61\x85' \
-                   b'\x5F\xBB\x63\xA2\x21\xCC\x46\xFC\x1E\x22\x6A\x07' \
-                   b'\x24\x11\xAF\x17\x5D\xDE\x47\x92\x81\xE0\x06\x87' \
-                   b'\x8B\x34\x80\x59'
+        expected = (
+            b"\xE5\xCB\x68\xB2\xF8\x43\xD6\x3B\xF4\x0B\xCB\x20"
+            b"\x07\x60\x8F\x81\x97\x61\x83\x92\x78\x3F\x23\x30"
+            b"\xE5\xEF\x19\xA5\xBD\x8F\x0B\x2F\xAA\xC8\x61\x85"
+            b"\x5F\xBB\x63\xA2\x21\xCC\x46\xFC\x1E\x22\x6A\x07"
+            b"\x24\x11\xAF\x17\x5D\xDE\x47\x92\x81\xE0\x06\x87"
+            b"\x8B\x34\x80\x59"
+        )
         actual = HTTPNegotiateAuth._get_certificate_hash(cert_der)
         assert actual == expected
 
     def test_invalid_signature_algorithm(self):
         # Manually edited from test_ecdsa_sha512 to change the OID to
         # '1.2.840.10045.4.3.5'
-        cert_der = b'MIIBjjCCATWgAwIBAgIQHVj2AGEwd6pOOSbcf0skQDAKBggqhkjOPQQ' \
-                   b'DBTAVMRMwEQYDVQQDDApTRVJWRVIyMDE2MB4XDTE3MDUzMDA3NTUzOV' \
-                   b'oXDTE4MDUzMDA4MTUzOVowFTETMBEGA1UEAwwKU0VSVkVSMjAxNjBZM' \
-                   b'BMGByqGSM49AgEGCCqGSM49AwEHA0IABL8d9S++MFpfzeH8B3vG/PjA' \
-                   b'AWg8tGJVgsMw9nR+OfC9ltbTUwhB+yPk3JPcfW/bqsyeUgq4//LhaSp' \
-                   b'lOWFNaNqjZzBlMA4GA1UdDwEB/wQEAwIFoDAdBgNVHSUEFjAUBggrBg' \
-                   b'EFBQcDAgYIKwYBBQUHAwEwFQYDVR0RBA4wDIIKU0VSVkVSMjAxNjAdB' \
-                   b'gNVHQ4EFgQUKUkCgLlxoeai0EtQrZth1/BSc5kwCgYIKoZIzj0EAwUD' \
-                   b'RwAwRAIgRrV7CLpDG7KueyFA3ZDced9dPOcv2Eydx/hgrfxYEcYCIBQ' \
-                   b'D35JvzmqU05kSFV5eTvkhkaDObd7V55vokhm31+Li'
+        cert_der = (
+            b"MIIBjjCCATWgAwIBAgIQHVj2AGEwd6pOOSbcf0skQDAKBggqhkjOPQQ"
+            b"DBTAVMRMwEQYDVQQDDApTRVJWRVIyMDE2MB4XDTE3MDUzMDA3NTUzOV"
+            b"oXDTE4MDUzMDA4MTUzOVowFTETMBEGA1UEAwwKU0VSVkVSMjAxNjBZM"
+            b"BMGByqGSM49AgEGCCqGSM49AwEHA0IABL8d9S++MFpfzeH8B3vG/PjA"
+            b"AWg8tGJVgsMw9nR+OfC9ltbTUwhB+yPk3JPcfW/bqsyeUgq4//LhaSp"
+            b"lOWFNaNqjZzBlMA4GA1UdDwEB/wQEAwIFoDAdBgNVHSUEFjAUBggrBg"
+            b"EFBQcDAgYIKwYBBQUHAwEwFQYDVR0RBA4wDIIKU0VSVkVSMjAxNjAdB"
+            b"gNVHQ4EFgQUKUkCgLlxoeai0EtQrZth1/BSc5kwCgYIKoZIzj0EAwUD"
+            b"RwAwRAIgRrV7CLpDG7KueyFA3ZDced9dPOcv2Eydx/hgrfxYEcYCIBQ"
+            b"D35JvzmqU05kSFV5eTvkhkaDObd7V55vokhm31+Li"
+        )
         cert_der = base64.b64decode(cert_der)
 
-        expected = b'\x65\xE1\xC7\x51\xAC\x33\xE0\x68\x03\xC3\xC9\xC2\x23\x45\x48\x43' \
-                   b'\x43\x25\x45\xD6\x4B\x49\x25\xF3\xAE\xB2\xDD\xE5\x9B\x79\xF4\x39'
+        expected = (
+            b"\x65\xE1\xC7\x51\xAC\x33\xE0\x68\x03\xC3\xC9\xC2\x23\x45\x48\x43"
+            b"\x43\x25\x45\xD6\x4B\x49\x25\xF3\xAE\xB2\xDD\xE5\x9B\x79\xF4\x39"
+        )
         expected_warning = "Failed to get the signature algorithm from the certificate due to:"
 
         with warnings.catch_warnings(record=True) as w:
@@ -342,19 +374,20 @@ class TestCertificateHash(object):
             assert actual == expected
             assert expected_warning in str(w[-1].message)
 
-    def test_get_cbt_fail_not_urllib3(self):
-        response = MagicMock()
+    def test_get_cbt_fail_not_urllib3(self, mocker):
+        response = mocker.MagicMock()
 
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             actual = HTTPNegotiateAuth._get_cbt_data(response)
             assert actual is None
-            assert str(w[-1].message) == \
-                "Requests is running with a non urllib3 backend, cannot " \
+            assert (
+                str(w[-1].message) == "Requests is running with a non urllib3 backend, cannot "
                 "retrieve server cert for CBT. Raw type: MagicMock"
+            )
 
-    def test_get_cbt_fail_invalid_raw_socket(self):
-        response = MagicMock()
+    def test_get_cbt_fail_invalid_raw_socket(self, mocker):
+        response = mocker.MagicMock()
         response.raw = HTTPResponse()
 
         expected_warning = "Failed to get raw socket for CBT from urllib3 resp"
@@ -364,58 +397,62 @@ class TestCertificateHash(object):
             assert actual is None
             assert expected_warning in str(w[-1].message)
 
-    def test_get_cbt_no_peer_cert(self):
-        mock_socket = MagicMock()
+    def test_get_cbt_no_peer_cert(self, mocker):
+        mock_socket = mocker.MagicMock()
         mock_socket.getpeercert.side_effect = AttributeError
 
         raw_response = HTTPResponse()
-        raw_response._fp = MagicMock()
+        raw_response._fp = mocker.MagicMock()
         raw_response._fp.fp.raw._sock = mock_socket
         raw_response._fp.fp._sock = mock_socket
 
-        response = MagicMock()
+        response = mocker.MagicMock()
         response.raw = raw_response
 
         actual = HTTPNegotiateAuth._get_cbt_data(response)
         assert actual is None
 
-    def test_get_cbt_with_peer_cert(self):
-        cert_der = b'MIIDGzCCAgOgAwIBAgIQWkeAtqoFg6pNWF7xC4YXhTANBgkqhkiG9w0' \
-                   b'BAQsFADAVMRMwEQYDVQQDDApTRVJWRVIyMDE2MB4XDTE3MDUyNzA5MD' \
-                   b'I0NFoXDTE4MDUyNzA5MjI0NFowFTETMBEGA1UEAwwKU0VSVkVSMjAxN' \
-                   b'jCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALIPKM5uykFy' \
-                   b'NmVoLyvPSXGk15ZDqjYi3AbUxVFwCkVImqhefLATit3PkTUYFtAT+TC' \
-                   b'AwK2E4lOu1XHM+Tmp2KIOnq2oUR8qMEvfxYThEf1MHxkctFljFssZ9N' \
-                   b'vASDD4lzw8r0Bhl+E5PhR22Eu1Wago5bvIldojkwG+WBxPQv3ZR546L' \
-                   b'MUZNaBXC0RhuGj5w83lbVz75qM98wvv1ekfZYAP7lrVyHxqCTPDomEU' \
-                   b'I45tQQZHCZl5nRx1fPCyyYfcfqvFlLWD4Q3PZAbnw6mi0MiWJbGYKME' \
-                   b'1XGicjqyn/zM9XKA1t/JzChS2bxf6rsyA9I7ibdRHUxsm1JgKry2jfW' \
-                   b'0CAwEAAaNnMGUwDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGA' \
-                   b'QUFBwMCBggrBgEFBQcDATAVBgNVHREEDjAMggpTRVJWRVIyMDE2MB0G' \
-                   b'A1UdDgQWBBQabLGWg1sn7AXPwYPyfE0ER921ZDANBgkqhkiG9w0BAQs' \
-                   b'FAAOCAQEAnRohyl6ZmOsTWCtxOJx5A8yr//NweXKwWWmFQXRmCb4bMC' \
-                   b'xhD4zqLDf5P6RotGV0I/SHvqz+pAtJuwmr+iyAF6WTzo3164LCfnQEu' \
-                   b'psfrrfMkf3txgDwQkA0oPAw3HEwOnR+tzprw3Yg9x6UoZEhi4XqP9AX' \
-                   b'R49jU92KrNXJcPlz5MbkzNo5t9nr2f8q39b5HBjaiBJxzdM1hxqsbfD' \
-                   b'KirTYbkUgPlVOo/NDmopPPb8IX8ubj/XETZG2jixD0zahgcZ1vdr/iZ' \
-                   b'+50WSXKN2TAKBO2fwoK+2/zIWrGRxJTARfQdF+fGKuj+AERIFNh88HW' \
-                   b'xSDYjHQAaFMcfdUpa9GGQ=='
+    def test_get_cbt_with_peer_cert(self, mocker):
+        cert_der = (
+            b"MIIDGzCCAgOgAwIBAgIQWkeAtqoFg6pNWF7xC4YXhTANBgkqhkiG9w0"
+            b"BAQsFADAVMRMwEQYDVQQDDApTRVJWRVIyMDE2MB4XDTE3MDUyNzA5MD"
+            b"I0NFoXDTE4MDUyNzA5MjI0NFowFTETMBEGA1UEAwwKU0VSVkVSMjAxN"
+            b"jCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALIPKM5uykFy"
+            b"NmVoLyvPSXGk15ZDqjYi3AbUxVFwCkVImqhefLATit3PkTUYFtAT+TC"
+            b"AwK2E4lOu1XHM+Tmp2KIOnq2oUR8qMEvfxYThEf1MHxkctFljFssZ9N"
+            b"vASDD4lzw8r0Bhl+E5PhR22Eu1Wago5bvIldojkwG+WBxPQv3ZR546L"
+            b"MUZNaBXC0RhuGj5w83lbVz75qM98wvv1ekfZYAP7lrVyHxqCTPDomEU"
+            b"I45tQQZHCZl5nRx1fPCyyYfcfqvFlLWD4Q3PZAbnw6mi0MiWJbGYKME"
+            b"1XGicjqyn/zM9XKA1t/JzChS2bxf6rsyA9I7ibdRHUxsm1JgKry2jfW"
+            b"0CAwEAAaNnMGUwDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGA"
+            b"QUFBwMCBggrBgEFBQcDATAVBgNVHREEDjAMggpTRVJWRVIyMDE2MB0G"
+            b"A1UdDgQWBBQabLGWg1sn7AXPwYPyfE0ER921ZDANBgkqhkiG9w0BAQs"
+            b"FAAOCAQEAnRohyl6ZmOsTWCtxOJx5A8yr//NweXKwWWmFQXRmCb4bMC"
+            b"xhD4zqLDf5P6RotGV0I/SHvqz+pAtJuwmr+iyAF6WTzo3164LCfnQEu"
+            b"psfrrfMkf3txgDwQkA0oPAw3HEwOnR+tzprw3Yg9x6UoZEhi4XqP9AX"
+            b"R49jU92KrNXJcPlz5MbkzNo5t9nr2f8q39b5HBjaiBJxzdM1hxqsbfD"
+            b"KirTYbkUgPlVOo/NDmopPPb8IX8ubj/XETZG2jixD0zahgcZ1vdr/iZ"
+            b"+50WSXKN2TAKBO2fwoK+2/zIWrGRxJTARfQdF+fGKuj+AERIFNh88HW"
+            b"xSDYjHQAaFMcfdUpa9GGQ=="
+        )
         cert_der = base64.b64decode(cert_der)
 
-        mock_socket = MagicMock()
+        mock_socket = mocker.MagicMock()
         mock_socket.getpeercert.return_value = cert_der
 
         raw_response = HTTPResponse()
-        raw_response._fp = MagicMock()
+        raw_response._fp = mocker.MagicMock()
         raw_response._fp.fp.raw._sock = mock_socket
         raw_response._fp.fp._sock = mock_socket
 
-        response = MagicMock()
+        response = mocker.MagicMock()
         response.raw = raw_response
 
-        expected = b"tls-server-end-point:" \
-                   b"\x99\x6F\x3E\xEA\x81\x2C\x18\x70\xE3\x05\x49\xFF" \
-                   b"\x9B\x86\xCD\x87\xA8\x90\xB6\xD8\xDF\xDF\x4A\x81" \
-                   b"\xBE\xF9\x67\x59\x70\xDA\xDB\x26"
+        expected = (
+            b"tls-server-end-point:"
+            b"\x99\x6F\x3E\xEA\x81\x2C\x18\x70\xE3\x05\x49\xFF"
+            b"\x9B\x86\xCD\x87\xA8\x90\xB6\xD8\xDF\xDF\x4A\x81"
+            b"\xBE\xF9\x67\x59\x70\xDA\xDB\x26"
+        )
         actual = HTTPNegotiateAuth._get_cbt_data(response)
         assert actual == expected

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -1,22 +1,16 @@
 # -*- coding: utf-8 -*-
 
+from collections import OrderedDict
+
 import pytest
 
 from pypsrp.exceptions import WSManFaultError
 from pypsrp.shell import Process, SignalCode, WinRS
 from pypsrp.wsman import WSMan
 
-try:
-    from collections import OrderedDict
-except ImportError:  # pragma: no cover
-    from ordereddict import OrderedDict
-
 
 class TestWinRS(object):
-
-    @pytest.mark.parametrize('wsman_conn',
-                             [[True, 'test_winrs_standard']],
-                             indirect=True)
+    @pytest.mark.parametrize("wsman_conn", [[True, "test_winrs_standard"]], indirect=True)
     def test_winrs_standard(self, wsman_conn):
         with WinRS(wsman_conn) as shell:
             process = Process(shell, "cmd.exe", ["/c", "echo", "hi"])
@@ -26,30 +20,31 @@ class TestWinRS(object):
             assert process.stdout == b"hi\r\n"
             assert process.stderr == b""
 
-    @pytest.mark.parametrize('wsman_conn',
-                             [[
-                                 # no_shell only works on older hosts, rely on
-                                 # pre-canned responses from actual test
-                                 False,
-                                 'test_winrs_no_cmd_shell'
-                             ]],
-                             indirect=True)
+    @pytest.mark.parametrize(
+        "wsman_conn",
+        [
+            [
+                # no_shell only works on older hosts, rely on
+                # pre-canned responses from actual test
+                False,
+                "test_winrs_no_cmd_shell",
+            ]
+        ],
+        indirect=True,
+    )
     def test_winrs_no_cmd_shell(self, wsman_conn):
         with WinRS(wsman_conn) as shell:
-            process = Process(shell, "powershell.exe", ["Write-Host", "hi"],
-                              no_shell=True)
+            process = Process(shell, "powershell.exe", ["Write-Host", "hi"], no_shell=True)
 
             # this will fail as you need to provide the full path when not
             # running in cmd shell
             with pytest.raises(WSManFaultError) as exc:
                 process.invoke()
-            assert exc.value.provider_fault == "The system cannot find the " \
-                                               "file specified."
+            assert exc.value.provider_fault == "The system cannot find the file specified."
             assert exc.value.code == 2147942402
 
             # fix the execute path and invoke again
-            process.executable = \
-                r"C:\Windows\system32\WindowsPowerShell\v1.0\powershell.exe"
+            process.executable = r"C:\Windows\system32\WindowsPowerShell\v1.0\powershell.exe"
             process.invoke()
             process.signal(SignalCode.CTRL_C)
 
@@ -57,78 +52,76 @@ class TestWinRS(object):
             assert process.stdout == b"hi\n"
             assert process.stderr == b""
 
-    @pytest.mark.parametrize('wsman_conn',
-                             [[
-                                 # to save on test runtime, only run with
-                                 # pre-canned responses
-                                 False,
-                                 'test_winrs_operation_timeout'
-                             ]],
-                             indirect=True)
+    @pytest.mark.parametrize(
+        "wsman_conn",
+        [
+            [
+                # to save on test runtime, only run with
+                # pre-canned responses
+                False,
+                "test_winrs_operation_timeout",
+            ]
+        ],
+        indirect=True,
+    )
     def test_winrs_operation_timeout(self, wsman_conn):
         wsman_conn.operation_timeout = 10
         with WinRS(wsman_conn) as shell:
-            process = Process(shell, "powershell.exe", ['Write-Host hi; '
-                                                        'Start-Sleep 30; '
-                                                        'Write-Host hi again'])
+            process = Process(shell, "powershell.exe", ["Write-Host hi; Start-Sleep 30; Write-Host hi again"])
             process.invoke()
             process.signal(SignalCode.CTRL_C)
             assert process.rc == 0
             assert process.stdout == b"hi\nhi again\n"
             assert process.stderr == b""
 
-    @pytest.mark.parametrize('wsman_conn',
-                             [[True, 'test_winrs_stderr_rc']], indirect=True)
+    @pytest.mark.parametrize("wsman_conn", [[True, "test_winrs_stderr_rc"]], indirect=True)
     def test_winrs_stderr_rc(self, wsman_conn):
         with WinRS(wsman_conn) as shell:
-            process = Process(shell, "cmd.exe", ["/c echo out && echo "
-                                                 "err>&2 && exit 1"])
+            process = Process(shell, "cmd.exe", ["/c echo out && echo err>&2 && exit 1"])
             process.invoke()
             process.signal(SignalCode.CTRL_C)
             assert process.rc == 1
             assert process.stdout == b"out \r\n"
             assert process.stderr == b"err \r\n"
 
-    @pytest.mark.parametrize('wsman_conn', [[True, 'test_winrs_send']],
-                             indirect=True)
+    @pytest.mark.parametrize("wsman_conn", [[True, "test_winrs_send"]], indirect=True)
     def test_winrs_send(self, wsman_conn):
         with WinRS(wsman_conn) as shell:
             process = Process(shell, "powershell.exe", ["-"])
             process.begin_invoke()
-            process.send(b"Write-Host \"output 1\";", end=False)
-            process.send(b"Write-Host \"output 2\";")
+            process.send(b'Write-Host "output 1";', end=False)
+            process.send(b'Write-Host "output 2";')
             process.end_invoke()
             process.signal(SignalCode.CTRL_C)
             assert process.rc == 0
             assert process.stdout == b"output 1\noutput 2\n"
             assert process.stderr == b""
 
-    @pytest.mark.parametrize('wsman_conn',
-                             [[True, 'test_winrs_environment']], indirect=True)
+    @pytest.mark.parametrize("wsman_conn", [[True, "test_winrs_environment"]], indirect=True)
     def test_winrs_environment(self, wsman_conn):
-        complex_chars = r'_-(){}[]<>*+-/\?"''!@#$^&|;:i,.`~0'
-        env_block = OrderedDict([
-            ('env1', 'var1'),
-            (1234, 5678),
-            (complex_chars, complex_chars),
-        ])
+        complex_chars = r'_-(){}[]<>*+-/\?"' "!@#$^&|;:i,.`~0"
+        env_block = OrderedDict(
+            [
+                ("env1", "var1"),
+                (1234, 5678),
+                (complex_chars, complex_chars),
+            ]
+        )
 
         with WinRS(wsman_conn, environment=env_block) as shell:
             process = Process(shell, "cmd.exe", ["/c", "set"])
             process.invoke()
             process.signal(SignalCode.CTRL_C)
-            env_list = process.stdout.decode('utf-8').splitlines()
+            env_list = process.stdout.decode("utf-8").splitlines()
             assert process.rc == 0
             assert "env1=var1" in env_list
             assert "1234=5678" in env_list
             assert "%s=%s" % (complex_chars, complex_chars) in env_list
             assert process.stderr == b""
 
-    @pytest.mark.parametrize('wsman_conn',
-                             [[True, 'test_winrs_extra_opts']], indirect=True)
+    @pytest.mark.parametrize("wsman_conn", [[True, "test_winrs_extra_opts"]], indirect=True)
     def test_winrs_extra_opts(self, wsman_conn):
-        with WinRS(wsman_conn, name="shell 1", lifetime=60, idle_time_out=60,
-                   working_directory="C:\\Windows") as shell:
+        with WinRS(wsman_conn, name="shell 1", lifetime=60, idle_time_out=60, working_directory="C:\\Windows") as shell:
             assert shell.name == "shell 1"
             assert shell.lifetime == 60
             assert shell.idle_time_out == "PT60.000S"
@@ -141,43 +134,39 @@ class TestWinRS(object):
             assert process.stdout == b"C:\\Windows\r\n"
             assert process.stderr == b""
 
-    @pytest.mark.parametrize('wsman_conn', [[True, 'test_winrs_unicode']],
-                             indirect=True)
+    @pytest.mark.parametrize("wsman_conn", [[True, "test_winrs_unicode"]], indirect=True)
     def test_winrs_unicode(self, wsman_conn):
         with WinRS(wsman_conn, codepage=65001) as shell:
-            process = Process(shell, "powershell.exe",
-                              [u"Write-Host こんにちは"])
+            process = Process(shell, "powershell.exe", [u"Write-Host こんにちは"])
             process.invoke()
             process.signal(SignalCode.CTRL_C)
             assert process.rc == 0
-            assert process.stdout.decode('utf-8') == u"こんにちは\n"
+            assert process.stdout.decode("utf-8") == u"こんにちは\n"
             assert process.stderr == b""
 
-    @pytest.mark.parametrize('wsman_conn',
-                             # not all hosts respect the no_profile, we will
-                             # just validate the message against a fake host
-                             [[False, 'test_winrs_noprofile']], indirect=True)
+    @pytest.mark.parametrize(
+        "wsman_conn",
+        # not all hosts respect the no_profile, we will
+        # just validate the message against a fake host
+        [[False, "test_winrs_noprofile"]],
+        indirect=True,
+    )
     def test_winrs_noprofile(self, wsman_conn):
         with WinRS(wsman_conn, no_profile=True) as shell:
             process = Process(shell, "cmd.exe", ["/c", "set"])
             process.invoke()
             process.signal(SignalCode.CTRL_C)
             assert process.rc == 0
-            assert "USERPROFILE=C:\\Users\\Default" in \
-                   process.stdout.decode('utf-8').splitlines()
+            assert "USERPROFILE=C:\\Users\\Default" in process.stdout.decode("utf-8").splitlines()
             assert process.stderr == b""
 
-    @pytest.mark.parametrize('wsman_conn',
-                             [[True, 'test_winrs_open_already_opened']],
-                             indirect=True)
+    @pytest.mark.parametrize("wsman_conn", [[True, "test_winrs_open_already_opened"]], indirect=True)
     def test_winrs_open_already_opened(self, wsman_conn):
         with WinRS(wsman_conn) as shell:
             shell.open()
         shell.close()
 
-    @pytest.mark.parametrize('wsman_conn',
-                             [[True, 'test_winrs_fail_poll_process']],
-                             indirect=True)
+    @pytest.mark.parametrize("wsman_conn", [[True, "test_winrs_fail_poll_process"]], indirect=True)
     def test_winrs_fail_poll_process(self, wsman_conn):
         with WinRS(wsman_conn) as shell:
             process = Process(shell, "cmd.exe", ["/c", "echo", "hi"])
@@ -186,14 +175,13 @@ class TestWinRS(object):
             with pytest.raises(WSManFaultError) as err:
                 process.poll_invoke()
             assert err.value.code == 87
-            assert err.value.message == \
-                "Received a WSManFault message. (Code: 87, Machine: {0}, " \
-                "Reason: The parameter is incorrect., Provider: Shell cmd " \
-                "plugin, Provider Path: %systemroot%\\system32\\winrscmd.dll" \
-                ", Provider Fault: The parameter is incorrect.)"\
-                .format(err.value.machine)
+            assert (
+                err.value.message == "Received a WSManFault message. (Code: 87, Machine: {0}, "
+                "Reason: The parameter is incorrect., Provider: Shell cmd "
+                "plugin, Provider Path: %systemroot%\\system32\\winrscmd.dll"
+                ", Provider Fault: The parameter is incorrect.)".format(err.value.machine)
+            )
             assert err.value.provider == "Shell cmd plugin"
             assert err.value.provider_fault == "The parameter is incorrect."
-            assert err.value.provider_path == \
-                "%systemroot%\\system32\\winrscmd.dll"
+            assert err.value.provider_path == "%systemroot%\\system32\\winrscmd.dll"
             assert err.value.reason == "The parameter is incorrect."

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,12 @@
 import pytest
 
-from pypsrp._utils import to_bytes, to_string, to_unicode, \
-    version_equal_or_newer, get_hostname
+from pypsrp._utils import (
+    get_hostname,
+    to_bytes,
+    to_string,
+    to_unicode,
+    version_equal_or_newer,
+)
 
 
 def test_unicode_to_bytes_default():
@@ -12,7 +17,7 @@ def test_unicode_to_bytes_default():
 
 def test_unicode_to_bytes_diff_encoding():
     expected = b"\x61\x00\x62\x00\x63\x00"
-    actual = to_bytes(u"abc", encoding='utf-16-le')
+    actual = to_bytes(u"abc", encoding="utf-16-le")
     assert actual == expected
 
 
@@ -27,7 +32,7 @@ def test_str_to_bytes():
     # be "abc" in UTF-16 form while Python 2 "abc" is the bytes representation
     # already
     expected = b"\x61\x00\x62\x00\x63\x00"
-    actual = to_bytes("abc", encoding='utf-16-le')
+    actual = to_bytes("abc", encoding="utf-16-le")
     assert actual == expected
 
 
@@ -45,13 +50,13 @@ def test_byte_to_unicode():
 
 def test_byte_to_unicode_diff_encoding():
     expected = u"abc"
-    actual = to_unicode(b"\x61\x00\x62\x00\x63\x00", encoding='utf-16-le')
+    actual = to_unicode(b"\x61\x00\x62\x00\x63\x00", encoding="utf-16-le")
     assert actual == expected
 
 
 def test_str_to_unicode():
     expected = u"a\x00b\x00c\x00"
-    actual = to_unicode("a\x00b\x00c\x00", encoding='utf-16-le')
+    actual = to_unicode("a\x00b\x00c\x00", encoding="utf-16-le")
     assert actual == expected
 
 
@@ -59,55 +64,57 @@ def test_to_str():
     assert str(to_string).startswith("<function to_unicode")
 
 
-@pytest.mark.parametrize('version, reference_version, expected',
-                         [
-                             ["2.2", "2.3", False],
-                             ["2.3", "2.3", True],
-                             ["2.4", "2.3", True],
-                             ["3", "2.3", True],
-                             ["3.0", "2.3", True],
-                             ["1", "2.3", False],
-                             ["1.0", "2.3", False],
-                             ["2.3.0", "2.3", True],
-                             ["2.3.1", "2.3", True],
-                             ["2.3", "2.3.0", True],
-                             ["2.3", "2.3.1", False],
-                         ])
+@pytest.mark.parametrize(
+    "version, reference_version, expected",
+    [
+        ["2.2", "2.3", False],
+        ["2.3", "2.3", True],
+        ["2.4", "2.3", True],
+        ["3", "2.3", True],
+        ["3.0", "2.3", True],
+        ["1", "2.3", False],
+        ["1.0", "2.3", False],
+        ["2.3.0", "2.3", True],
+        ["2.3.1", "2.3", True],
+        ["2.3", "2.3.0", True],
+        ["2.3", "2.3.1", False],
+    ],
+)
 def test_version_newer(version, reference_version, expected):
     assert version_equal_or_newer(version, reference_version) == expected
 
 
-@pytest.mark.parametrize('url, expected',
-                         [
-                             # hostname
-                             ['http://hostname', 'hostname'],
-                             ['https://hostname', 'hostname'],
-                             ['http://hostname:1234', 'hostname'],
-                             ['https://hostname:1234', 'hostname'],
-                             ['http://hostname/path', 'hostname'],
-                             ['https://hostname/path', 'hostname'],
-                             ['http://hostname:1234/path', 'hostname'],
-                             ['https://hostname:1234/path', 'hostname'],
-
-                             # fqdn
-                             ['http://hostname.domain.com', 'hostname.domain.com'],
-                             ['https://hostname.domain.com', 'hostname.domain.com'],
-                             ['http://hostname.domain.com:1234', 'hostname.domain.com'],
-                             ['https://hostname.domain.com:1234', 'hostname.domain.com'],
-                             ['http://hostname.domain.com/path', 'hostname.domain.com'],
-                             ['https://hostname.domain.com/path', 'hostname.domain.com'],
-                             ['http://hostname.domain.com:1234/path', 'hostname.domain.com'],
-                             ['https://hostname.domain.com:1234/path', 'hostname.domain.com'],
-
-                             # ip address
-                             ['http://1.2.3.4', '1.2.3.4'],
-                             ['https://1.2.3.4', '1.2.3.4'],
-                             ['http://1.2.3.4:1234', '1.2.3.4'],
-                             ['https://1.2.3.4:1234', '1.2.3.4'],
-                             ['http://1.2.3.4/path', '1.2.3.4'],
-                             ['https://1.2.3.4/path', '1.2.3.4'],
-                             ['http://1.2.3.4:1234/path', '1.2.3.4'],
-                             ['https://1.2.3.4:1234/path', '1.2.3.4'],
-                         ])
+@pytest.mark.parametrize(
+    "url, expected",
+    [
+        # hostname
+        ["http://hostname", "hostname"],
+        ["https://hostname", "hostname"],
+        ["http://hostname:1234", "hostname"],
+        ["https://hostname:1234", "hostname"],
+        ["http://hostname/path", "hostname"],
+        ["https://hostname/path", "hostname"],
+        ["http://hostname:1234/path", "hostname"],
+        ["https://hostname:1234/path", "hostname"],
+        # fqdn
+        ["http://hostname.domain.com", "hostname.domain.com"],
+        ["https://hostname.domain.com", "hostname.domain.com"],
+        ["http://hostname.domain.com:1234", "hostname.domain.com"],
+        ["https://hostname.domain.com:1234", "hostname.domain.com"],
+        ["http://hostname.domain.com/path", "hostname.domain.com"],
+        ["https://hostname.domain.com/path", "hostname.domain.com"],
+        ["http://hostname.domain.com:1234/path", "hostname.domain.com"],
+        ["https://hostname.domain.com:1234/path", "hostname.domain.com"],
+        # ip address
+        ["http://1.2.3.4", "1.2.3.4"],
+        ["https://1.2.3.4", "1.2.3.4"],
+        ["http://1.2.3.4:1234", "1.2.3.4"],
+        ["https://1.2.3.4:1234", "1.2.3.4"],
+        ["http://1.2.3.4/path", "1.2.3.4"],
+        ["https://1.2.3.4/path", "1.2.3.4"],
+        ["http://1.2.3.4:1234/path", "1.2.3.4"],
+        ["https://1.2.3.4:1234/path", "1.2.3.4"],
+    ],
+)
 def test_get_hostname(url, expected):
     assert expected == get_hostname(url)

--- a/tests/test_wsman.py
+++ b/tests/test_wsman.py
@@ -1,21 +1,26 @@
 import os
-import requests
 import uuid
 import xml.etree.ElementTree as ET
 
 import pytest
+import requests
 
 from pypsrp.encryption import WinRMEncryption
-from pypsrp.exceptions import AuthenticationError, WinRMError, \
-    WinRMTransportError, WSManFaultError
+from pypsrp.exceptions import (
+    AuthenticationError,
+    WinRMError,
+    WinRMTransportError,
+    WSManFaultError,
+)
 from pypsrp.negotiate import HTTPNegotiateAuth
-from pypsrp.wsman import OptionSet, SelectorSet, WSMan, WSManAction, \
-    NAMESPACES, _TransportHTTP
-
-try:
-    from unittest.mock import MagicMock
-except ImportError:
-    from mock import MagicMock
+from pypsrp.wsman import (
+    NAMESPACES,
+    OptionSet,
+    SelectorSet,
+    WSMan,
+    WSManAction,
+    _TransportHTTP,
+)
 
 try:
     import requests_credssp
@@ -24,7 +29,6 @@ except ImportError:
 
 
 class _TransportTest(object):
-
     def __init__(self, expected_action=None):
         self.endpoint = "testendpoint"
         self.expected_action = expected_action
@@ -40,17 +44,17 @@ class _TransportTest(object):
         req = ET.fromstring(xml)
         action = req.find("s:Header/wsa:Action", NAMESPACES).text
         if action == self.expected_action:
-            return '''<s:Envelope xml:lang="en-US" xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing">
+            return """<s:Envelope xml:lang="en-US" xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing">
                 <s:Header>
                     <wsa:RelatesTo>uuid:00000000-0000-0000-0000-000000000000</wsa:RelatesTo>
                 </s:Header>
                 <s:Body>body</s:Body>
-            </s:Envelope>'''
+            </s:Envelope>"""
         else:
             # we want to set a non XML message as the response text to verify
             # the parsing failure is checked and the original exception is
             # raised
-            error_msg = '''<s:Envelope xml:lang="en-US" xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:x="http://schemas.xmlsoap.org/ws/2004/09/transfer" xmlns:e="http://schemas.xmlsoap.org/ws/2004/08/eventing" xmlns:n="http://schemas.xmlsoap.org/ws/2004/09/enumeration" xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd" xmlns:rsp="http://schemas.microsoft.com/wbem/wsman/1/windows/shell" xmlns:p="http://schemas.microsoft.com/wbem/wsman/1/wsman.xsd"><s:Header><a:Action>http://schemas.xmlsoap.org/ws/2004/08/addressing/fault</a:Action><a:MessageID>uuid:4DB571F9-F8DE-48FD-872C-2AF08D996249</a:MessageID><a:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:To><a:RelatesTo>uuid:eaa98952-3188-458f-b265-b03ace115f20</a:RelatesTo><s:NotUnderstood qname="wsman:ResourceUri" xmlns:wsman="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd" />
+            error_msg = """<s:Envelope xml:lang="en-US" xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:x="http://schemas.xmlsoap.org/ws/2004/09/transfer" xmlns:e="http://schemas.xmlsoap.org/ws/2004/08/eventing" xmlns:n="http://schemas.xmlsoap.org/ws/2004/09/enumeration" xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd" xmlns:rsp="http://schemas.microsoft.com/wbem/wsman/1/windows/shell" xmlns:p="http://schemas.microsoft.com/wbem/wsman/1/wsman.xsd"><s:Header><a:Action>http://schemas.xmlsoap.org/ws/2004/08/addressing/fault</a:Action><a:MessageID>uuid:4DB571F9-F8DE-48FD-872C-2AF08D996249</a:MessageID><a:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:To><a:RelatesTo>uuid:eaa98952-3188-458f-b265-b03ace115f20</a:RelatesTo><s:NotUnderstood qname="wsman:ResourceUri" xmlns:wsman="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd" />
                 </s:Header>
                 <s:Body>
                     <s:Fault>
@@ -62,12 +66,14 @@ class _TransportTest(object):
                         </s:Reason>
                     </s:Fault>
                 </s:Body>
-            </s:Envelope>''' % (action, self.expected_action)
+            </s:Envelope>""" % (
+                action,
+                self.expected_action,
+            )
             raise WinRMTransportError("http", 500, error_msg)
 
 
 class TestWSMan(object):
-
     def test_wsman_defaults(self):
         actual = WSMan("")
         assert actual.max_envelope_size == 153600
@@ -88,7 +94,8 @@ class TestWSMan(object):
     def test_invoke_command(self, monkeypatch):
         def mockuuid():
             return uuid.UUID("00000000-0000-0000-0000-000000000000")
-        monkeypatch.setattr(uuid, 'uuid4', mockuuid)
+
+        monkeypatch.setattr(uuid, "uuid4", mockuuid)
 
         wsman = WSMan("")
         wsman.transport = _TransportTest(WSManAction.COMMAND)
@@ -99,7 +106,8 @@ class TestWSMan(object):
     def test_invoke_connect(self, monkeypatch):
         def mockuuid():
             return uuid.UUID("00000000-0000-0000-0000-000000000000")
-        monkeypatch.setattr(uuid, 'uuid4', mockuuid)
+
+        monkeypatch.setattr(uuid, "uuid4", mockuuid)
 
         wsman = WSMan("")
         wsman.transport = _TransportTest(WSManAction.CONNECT)
@@ -110,7 +118,8 @@ class TestWSMan(object):
     def test_invoke_create(self, monkeypatch):
         def mockuuid():
             return uuid.UUID("00000000-0000-0000-0000-000000000000")
-        monkeypatch.setattr(uuid, 'uuid4', mockuuid)
+
+        monkeypatch.setattr(uuid, "uuid4", mockuuid)
 
         wsman = WSMan("")
         wsman.transport = _TransportTest(WSManAction.CREATE)
@@ -121,7 +130,8 @@ class TestWSMan(object):
     def test_invoke_disconnect(self, monkeypatch):
         def mockuuid():
             return uuid.UUID("00000000-0000-0000-0000-000000000000")
-        monkeypatch.setattr(uuid, 'uuid4', mockuuid)
+
+        monkeypatch.setattr(uuid, "uuid4", mockuuid)
 
         wsman = WSMan("")
         wsman.transport = _TransportTest(WSManAction.DISCONNECT)
@@ -132,7 +142,8 @@ class TestWSMan(object):
     def test_invoke_enumerate(self, monkeypatch):
         def mockuuid():
             return uuid.UUID("00000000-0000-0000-0000-000000000000")
-        monkeypatch.setattr(uuid, 'uuid4', mockuuid)
+
+        monkeypatch.setattr(uuid, "uuid4", mockuuid)
 
         wsman = WSMan("")
         wsman.transport = _TransportTest(WSManAction.ENUMERATE)
@@ -143,7 +154,8 @@ class TestWSMan(object):
     def test_invoke_delete(self, monkeypatch):
         def mockuuid():
             return uuid.UUID("00000000-0000-0000-0000-000000000000")
-        monkeypatch.setattr(uuid, 'uuid4', mockuuid)
+
+        monkeypatch.setattr(uuid, "uuid4", mockuuid)
 
         wsman = WSMan("")
         wsman.transport = _TransportTest(WSManAction.DELETE)
@@ -154,7 +166,8 @@ class TestWSMan(object):
     def test_invoke_get(self, monkeypatch):
         def mockuuid():
             return uuid.UUID("00000000-0000-0000-0000-000000000000")
-        monkeypatch.setattr(uuid, 'uuid4', mockuuid)
+
+        monkeypatch.setattr(uuid, "uuid4", mockuuid)
 
         wsman = WSMan("")
         wsman.transport = _TransportTest(WSManAction.GET)
@@ -165,7 +178,8 @@ class TestWSMan(object):
     def test_invoke_pull(self, monkeypatch):
         def mockuuid():
             return uuid.UUID("00000000-0000-0000-0000-000000000000")
-        monkeypatch.setattr(uuid, 'uuid4', mockuuid)
+
+        monkeypatch.setattr(uuid, "uuid4", mockuuid)
 
         wsman = WSMan("")
         wsman.transport = _TransportTest(WSManAction.PULL)
@@ -176,7 +190,8 @@ class TestWSMan(object):
     def test_invoke_put(self, monkeypatch):
         def mockuuid():
             return uuid.UUID("00000000-0000-0000-0000-000000000000")
-        monkeypatch.setattr(uuid, 'uuid4', mockuuid)
+
+        monkeypatch.setattr(uuid, "uuid4", mockuuid)
 
         wsman = WSMan("")
         wsman.transport = _TransportTest(WSManAction.PUT)
@@ -187,7 +202,8 @@ class TestWSMan(object):
     def test_invoke_receive(self, monkeypatch):
         def mockuuid():
             return uuid.UUID("00000000-0000-0000-0000-000000000000")
-        monkeypatch.setattr(uuid, 'uuid4', mockuuid)
+
+        monkeypatch.setattr(uuid, "uuid4", mockuuid)
 
         wsman = WSMan("")
         wsman.transport = _TransportTest(WSManAction.RECEIVE)
@@ -198,7 +214,8 @@ class TestWSMan(object):
     def test_invoke_reconnect(self, monkeypatch):
         def mockuuid():
             return uuid.UUID("00000000-0000-0000-0000-000000000000")
-        monkeypatch.setattr(uuid, 'uuid4', mockuuid)
+
+        monkeypatch.setattr(uuid, "uuid4", mockuuid)
 
         wsman = WSMan("")
         wsman.transport = _TransportTest(WSManAction.RECONNECT)
@@ -209,7 +226,8 @@ class TestWSMan(object):
     def test_invoke_send(self, monkeypatch):
         def mockuuid():
             return uuid.UUID("00000000-0000-0000-0000-000000000000")
-        monkeypatch.setattr(uuid, 'uuid4', mockuuid)
+
+        monkeypatch.setattr(uuid, "uuid4", mockuuid)
 
         wsman = WSMan("")
         wsman.transport = _TransportTest(WSManAction.SEND)
@@ -220,7 +238,8 @@ class TestWSMan(object):
     def test_invoke_signal(self, monkeypatch):
         def mockuuid():
             return uuid.UUID("00000000-0000-0000-0000-000000000000")
-        monkeypatch.setattr(uuid, 'uuid4', mockuuid)
+
+        monkeypatch.setattr(uuid, "uuid4", mockuuid)
 
         wsman = WSMan("")
         wsman.transport = _TransportTest(WSManAction.SIGNAL)
@@ -230,65 +249,66 @@ class TestWSMan(object):
 
     def test_get_header_no_locale(self):
         wsman = WSMan("")
-        actual = wsman._create_header("action", "resource", None, None, None)
+        _, actual = wsman._create_header("action", "resource", None, None, None)
         actual_data_locale = actual.find("wsmv:DataLocale", NAMESPACES)
         actual_locale = actual.find("wsman:Locale", NAMESPACES)
 
-        xml = NAMESPACES['xml']
+        xml = NAMESPACES["xml"]
         assert actual_data_locale.attrib["{%s}lang" % xml] == "en-US"
         assert actual_locale.attrib["{%s}lang" % xml] == "en-US"
 
     def test_get_header_explicit_locale(self):
         wsman = WSMan("", locale="en-GB")
-        actual = wsman._create_header("action", "resource", None, None, None)
+        _, actual = wsman._create_header("action", "resource", None, None, None)
         actual_data_locale = actual.find("wsmv:DataLocale", NAMESPACES)
         actual_locale = actual.find("wsman:Locale", NAMESPACES)
 
-        xml = NAMESPACES['xml']
+        xml = NAMESPACES["xml"]
         assert actual_data_locale.attrib["{%s}lang" % xml] == "en-GB"
         assert actual_locale.attrib["{%s}lang" % xml] == "en-GB"
 
     def test_get_header_explicit_data_locale(self):
         wsman = WSMan("", data_locale="en-GB")
-        actual = wsman._create_header("action", "resource", None, None, None)
+        _, actual = wsman._create_header("action", "resource", None, None, None)
         actual_data_locale = actual.find("wsmv:DataLocale", NAMESPACES)
         actual_locale = actual.find("wsman:Locale", NAMESPACES)
 
-        xml = NAMESPACES['xml']
+        xml = NAMESPACES["xml"]
         assert actual_data_locale.attrib["{%s}lang" % xml] == "en-GB"
         assert actual_locale.attrib["{%s}lang" % xml] == "en-US"
 
     def test_get_header_explicit_both_locale(self):
         wsman = WSMan("", locale="en-AU", data_locale="en-GB")
-        actual = wsman._create_header("action", "resource", None, None, None)
+        _, actual = wsman._create_header("action", "resource", None, None, None)
         actual_data_locale = actual.find("wsmv:DataLocale", NAMESPACES)
         actual_locale = actual.find("wsman:Locale", NAMESPACES)
 
-        xml = NAMESPACES['xml']
+        xml = NAMESPACES["xml"]
         assert actual_data_locale.attrib["{%s}lang" % xml] == "en-GB"
         assert actual_locale.attrib["{%s}lang" % xml] == "en-AU"
 
     def test_invoke_mismatch_id(self, monkeypatch):
         def mockuuid():
             return uuid.UUID("00000000-0000-0000-0000-000000000001")
-        monkeypatch.setattr(uuid, 'uuid4', mockuuid)
+
+        monkeypatch.setattr(uuid, "uuid4", mockuuid)
 
         wsman = WSMan("")
         wsman.transport = _TransportTest(WSManAction.SEND)
         with pytest.raises(WinRMError) as exc:
             wsman.send("", None)
-        assert str(exc.value) == \
-            "Received related id does not match related expected message " \
-            "id: Sent: uuid:00000000-0000-0000-0000-000000000001, Received: " \
+        assert (
+            str(exc.value) == "Received related id does not match related expected message "
+            "id: Sent: uuid:00000000-0000-0000-0000-000000000001, Received: "
             "uuid:00000000-0000-0000-0000-000000000000"
+        )
 
     def test_invoke_transport_error(self):
         wsman = WSMan("")
         wsman.transport = _TransportTest()
         with pytest.raises(WinRMTransportError) as exc:
             wsman.send("", None)
-        error_msg = "Bad HTTP response returned from the server. Code: 401, " \
-                    "Content: 'not an XML response'"
+        error_msg = "Bad HTTP response returned from the server. Code: 401, Content: 'not an XML response'"
         assert str(exc.value) == error_msg
         assert exc.value.code == 401
         assert exc.value.protocol == "http"
@@ -302,21 +322,20 @@ class TestWSMan(object):
         wsman.transport = _TransportTest(WSManAction.CREATE)
         with pytest.raises(WSManFaultError) as exc:
             wsman.send("", None)
-        error_msg = \
-            "Received a WSManFault message. (Code: IllegalAction, Reason: " \
-            "Illegal action '%s', expecting '%s')" \
-            % (WSManAction.SEND, WSManAction.CREATE)
+        error_msg = (
+            "Received a WSManFault message. (Code: IllegalAction, Reason: "
+            "Illegal action '%s', expecting '%s')" % (WSManAction.SEND, WSManAction.CREATE)
+        )
         assert str(exc.value) == error_msg
         assert exc.value.code == "IllegalAction"
         assert exc.value.machine is None
         assert exc.value.message == error_msg
         assert exc.value.provider is None
         assert exc.value.provider_fault is None
-        assert exc.value.reason == "Illegal action '%s', expecting '%s'" \
-            % (WSManAction.SEND, WSManAction.CREATE)
+        assert exc.value.reason == "Illegal action '%s', expecting '%s'" % (WSManAction.SEND, WSManAction.CREATE)
 
     def test_raise_native_wsman_fault(self):
-        xml_text = '''
+        xml_text = """
         <s:Envelope xml:lang="en-US" xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:x="http://schemas.xmlsoap.org/ws/2004/09/transfer" xmlns:e="http://schemas.xmlsoap.org/ws/2004/08/eventing" xmlns:n="http://schemas.xmlsoap.org/ws/2004/09/enumeration" xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd" xmlns:rsp="http://schemas.microsoft.com/wbem/wsman/1/windows/shell" xmlns:p="http://schemas.microsoft.com/wbem/wsman/1/wsman.xsd"><s:Header><a:Action>http://schemas.xmlsoap.org/ws/2004/08/addressing/fault</a:Action><a:MessageID>uuid:4DB571F9-F8DE-48FD-872C-2AF08D996249</a:MessageID><a:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:To><a:RelatesTo>uuid:eaa98952-3188-458f-b265-b03ace115f20</a:RelatesTo><s:NotUnderstood qname="wsman:ResourceUri" xmlns:wsman="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd" />
             </s:Header>
             <s:Body>
@@ -329,30 +348,32 @@ class TestWSMan(object):
                     </s:Reason>
                 </s:Fault>
             </s:Body>
-        </s:Envelope>'''
+        </s:Envelope>"""
         with pytest.raises(WSManFaultError) as exc:
             raise WSMan._parse_wsman_fault(xml_text)
         assert exc.value.code == "s:MustUnderstand"
         assert exc.value.machine is None
-        assert exc.value.message == \
-            "Received a WSManFault message. (Code: s:MustUnderstand, " \
-            "Reason: The WS-Management service cannot process a SOAP header " \
-            "in the request that is marked as mustUnderstand by the client. " \
-            " This could be caused by the use of a version of the protocol " \
-            "which is not supported, or may be an incompatibility  between " \
+        assert (
+            exc.value.message == "Received a WSManFault message. (Code: s:MustUnderstand, "
+            "Reason: The WS-Management service cannot process a SOAP header "
+            "in the request that is marked as mustUnderstand by the client. "
+            " This could be caused by the use of a version of the protocol "
+            "which is not supported, or may be an incompatibility  between "
             "the client and server implementations.)"
+        )
         assert exc.value.provider is None
         assert exc.value.provider_fault is None
         assert exc.value.provider_path is None
-        assert exc.value.reason == \
-            "The WS-Management service cannot process a SOAP header in the " \
-            "request that is marked as mustUnderstand by the client.  This " \
-            "could be caused by the use of a version of the protocol which " \
-            "is not supported, or may be an incompatibility  between the " \
+        assert (
+            exc.value.reason == "The WS-Management service cannot process a SOAP header in the "
+            "request that is marked as mustUnderstand by the client.  This "
+            "could be caused by the use of a version of the protocol which "
+            "is not supported, or may be an incompatibility  between the "
             "client and server implementations."
+        )
 
     def test_raise_native_wsman_fault_no_reason(self):
-        xml_text = '''
+        xml_text = """
         <s:Envelope xml:lang="en-US" xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:x="http://schemas.xmlsoap.org/ws/2004/09/transfer" xmlns:e="http://schemas.xmlsoap.org/ws/2004/08/eventing" xmlns:n="http://schemas.xmlsoap.org/ws/2004/09/enumeration" xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd" xmlns:rsp="http://schemas.microsoft.com/wbem/wsman/1/windows/shell" xmlns:p="http://schemas.microsoft.com/wbem/wsman/1/wsman.xsd"><s:Header><a:Action>http://schemas.xmlsoap.org/ws/2004/08/addressing/fault</a:Action><a:MessageID>uuid:4DB571F9-F8DE-48FD-872C-2AF08D996249</a:MessageID><a:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:To><a:RelatesTo>uuid:eaa98952-3188-458f-b265-b03ace115f20</a:RelatesTo><s:NotUnderstood qname="wsman:ResourceUri" xmlns:wsman="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd" />
             </s:Header>
             <s:Body>
@@ -362,20 +383,19 @@ class TestWSMan(object):
                     </s:Code>
                 </s:Fault>
             </s:Body>
-        </s:Envelope>'''
+        </s:Envelope>"""
         with pytest.raises(WSManFaultError) as exc:
             raise WSMan._parse_wsman_fault(xml_text)
         assert exc.value.code == "s:Unknown"
         assert exc.value.machine is None
-        assert exc.value.message == "Received a WSManFault message. " \
-                                    "(Code: s:Unknown)"
+        assert exc.value.message == "Received a WSManFault message. (Code: s:Unknown)"
         assert exc.value.provider is None
         assert exc.value.provider_fault is None
         assert exc.value.provider_path is None
         assert exc.value.reason is None
 
     def test_raise_wsman_fault_with_wsman_fault(self):
-        xml_text = r'''
+        xml_text = r"""
         <s:Envelope xml:lang="en-US" xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:x="http://schemas.xmlsoap.org/ws/2004/09/transfer" xmlns:e="http://schemas.xmlsoap.org/ws/2004/08/eventing" xmlns:n="http://schemas.xmlsoap.org/ws/2004/09/enumeration" xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd" xmlns:p="http://schemas.microsoft.com/wbem/wsman/1/wsman.xsd">
             <s:Header>
                 <a:Action>http://schemas.dmtf.org/wbem/wsman/1/wsman/fault</a:Action>
@@ -402,25 +422,25 @@ class TestWSMan(object):
                     </s:Detail>
                 </s:Fault>
             </s:Body>
-        </s:Envelope>'''
+        </s:Envelope>"""
         with pytest.raises(WSManFaultError) as exc:
             raise WSMan._parse_wsman_fault(xml_text)
         assert exc.value.code == 87
         assert exc.value.machine == "SERVER2016.domain.local"
-        assert exc.value.message == \
-            "Received a WSManFault message. (Code: 87, Machine: " \
-            "SERVER2016.domain.local, Reason: The parameter is incorrect., " \
-            "Provider: Shell cmd plugin, Provider Path: %systemroot%\\" \
-            "system32\\winrscmd.dll, Provider Fault: The parameter is " \
+        assert (
+            exc.value.message == "Received a WSManFault message. (Code: 87, Machine: "
+            "SERVER2016.domain.local, Reason: The parameter is incorrect., "
+            "Provider: Shell cmd plugin, Provider Path: %systemroot%\\"
+            "system32\\winrscmd.dll, Provider Fault: The parameter is "
             "incorrect.)"
+        )
         assert exc.value.provider == "Shell cmd plugin"
         assert exc.value.provider_fault == "The parameter is incorrect."
-        assert exc.value.provider_path == \
-            "%systemroot%\\system32\\winrscmd.dll"
+        assert exc.value.provider_path == "%systemroot%\\system32\\winrscmd.dll"
         assert exc.value.reason == "The parameter is incorrect."
 
     def test_raise_wsman_fault_without_provider(self):
-        xml_text = r'''
+        xml_text = r"""
         <s:Envelope xml:lang="en-US" xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:x="http://schemas.xmlsoap.org/ws/2004/09/transfer" xmlns:e="http://schemas.xmlsoap.org/ws/2004/08/eventing" xmlns:n="http://schemas.xmlsoap.org/ws/2004/09/enumeration" xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd" xmlns:p="http://schemas.microsoft.com/wbem/wsman/1/wsman.xsd">
             <s:Header>
                 <a:Action>http://schemas.dmtf.org/wbem/wsman/1/wsman/fault</a:Action>
@@ -446,24 +466,26 @@ class TestWSMan(object):
                     </s:Detail>
                 </s:Fault>
             </s:Body>
-        </s:Envelope>'''
+        </s:Envelope>"""
         with pytest.raises(WSManFaultError) as exc:
             raise WSMan._parse_wsman_fault(xml_text)
         assert exc.value.code == 2150858817
         assert exc.value.machine == "SERVER2008.domain.local"
-        assert exc.value.message == \
-            "Received a WSManFault message. (Code: 2150858817, Machine: " \
-            "SERVER2008.domain.local, Reason: The Windows Remote Shell " \
-            "cannot process the request. The SOAP packet contains an " \
-            "element Argument that is invalid. Retry the request with the " \
+        assert (
+            exc.value.message == "Received a WSManFault message. (Code: 2150858817, Machine: "
+            "SERVER2008.domain.local, Reason: The Windows Remote Shell "
+            "cannot process the request. The SOAP packet contains an "
+            "element Argument that is invalid. Retry the request with the "
             "correct XML element.)"
+        )
         assert exc.value.provider is None
         assert exc.value.provider_fault is None
         assert exc.value.provider_path is None
-        assert exc.value.reason == \
-            "The Windows Remote Shell cannot process the request. The SOAP " \
-            "packet contains an element Argument that is invalid. Retry the " \
+        assert (
+            exc.value.reason == "The Windows Remote Shell cannot process the request. The SOAP "
+            "packet contains an element Argument that is invalid. Retry the "
             "request with the correct XML element."
+        )
 
     def test_wsman_update_envelope_size_explicit(self):
         wsman = WSMan("")
@@ -473,11 +495,13 @@ class TestWSMan(object):
         # version and rounding differences, we will just assert against a range
         assert 1450 <= wsman.max_payload_size <= 1835
 
-    @pytest.mark.parametrize('wsman_conn',
-                             # we just want to validate against different env
-                             # set on a server
-                             [[False, 'test_wsman_update_envelope_size_150']],
-                             indirect=True)
+    @pytest.mark.parametrize(
+        "wsman_conn",
+        # we just want to validate against different env
+        # set on a server
+        [[False, "test_wsman_update_envelope_size_150"]],
+        indirect=True,
+    )
     def test_wsman_update_envelope_size_150(self, wsman_conn):
         wsman_conn.update_max_payload_size()
         assert wsman_conn.max_envelope_size == 153600
@@ -485,11 +509,13 @@ class TestWSMan(object):
         # version and rounding differences, we will just assert against a range
         assert 113574 <= wsman_conn.max_payload_size <= 113952
 
-    @pytest.mark.parametrize('wsman_conn',
-                             # we just want to validate against different env
-                             # set on a server
-                             [[False, 'test_wsman_update_envelope_size_500']],
-                             indirect=True)
+    @pytest.mark.parametrize(
+        "wsman_conn",
+        # we just want to validate against different env
+        # set on a server
+        [[False, "test_wsman_update_envelope_size_500"]],
+        indirect=True,
+    )
     def test_wsman_update_envelope_size_500(self, wsman_conn):
         wsman_conn.update_max_payload_size()
         assert wsman_conn.max_envelope_size == 512000
@@ -497,11 +523,13 @@ class TestWSMan(object):
         # version and rounding differences, we will just assert against a range
         assert 382374 <= wsman_conn.max_payload_size <= 382752
 
-    @pytest.mark.parametrize('wsman_conn',
-                             # we just want to validate against different env
-                             # set on a server
-                             [[False, 'test_wsman_update_envelope_size_4096']],
-                             indirect=True)
+    @pytest.mark.parametrize(
+        "wsman_conn",
+        # we just want to validate against different env
+        # set on a server
+        [[False, "test_wsman_update_envelope_size_4096"]],
+        indirect=True,
+    )
     def test_wsman_update_envelope_size_4096(self, wsman_conn):
         wsman_conn.update_max_payload_size()
         assert wsman_conn.max_envelope_size == 4194304
@@ -511,15 +539,12 @@ class TestWSMan(object):
 
 
 class TestOptionSet(object):
-
     def test_set_no_options(self):
         option_set = OptionSet()
         actual = option_set.pack()
         assert len(actual.attrib.keys()) == 1
-        assert actual.attrib['{http://www.w3.org/2003/05/soap-envelope}'
-                             'mustUnderstand'] == 'true'
-        assert actual.tag == \
-            "{http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd}OptionSet"
+        assert actual.attrib["{http://www.w3.org/2003/05/soap-envelope}mustUnderstand"] == "true"
+        assert actual.tag == "{http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd}OptionSet"
         assert actual.text is None
         assert list(actual) == []
         assert str(option_set) == "{}"
@@ -529,39 +554,32 @@ class TestOptionSet(object):
         option_set.add_option("key", "value")
         actual = option_set.pack()
         assert len(actual.attrib.keys()) == 1
-        assert actual.attrib['{http://www.w3.org/2003/05/soap-envelope}'
-                             'mustUnderstand'] == 'true'
-        assert actual.tag == \
-            "{http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd}OptionSet"
+        assert actual.attrib["{http://www.w3.org/2003/05/soap-envelope}mustUnderstand"] == "true"
+        assert actual.tag == "{http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd}OptionSet"
         assert actual.text is None
         children = list(actual)
         assert len(children) == 1
         assert len(children[0].attrib.keys()) == 1
-        assert children[0].attrib['Name'] == "key"
-        assert children[0].tag == \
-            "{http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd}Option"
+        assert children[0].attrib["Name"] == "key"
+        assert children[0].tag == "{http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd}Option"
         assert children[0].text == "value"
         assert str(option_set) == "{'key': 'value'}"
 
     def test_set_one_option_with_attributes(self):
         option_set = OptionSet()
-        option_set.add_option("key", "value",
-                              {"attrib1": "value1", "attrib2": "value2"})
+        option_set.add_option("key", "value", {"attrib1": "value1", "attrib2": "value2"})
         actual = option_set.pack()
         assert len(actual.attrib.keys()) == 1
-        assert actual.attrib['{http://www.w3.org/2003/05/soap-envelope}'
-                             'mustUnderstand'] == 'true'
-        assert actual.tag == \
-            "{http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd}OptionSet"
+        assert actual.attrib["{http://www.w3.org/2003/05/soap-envelope}mustUnderstand"] == "true"
+        assert actual.tag == "{http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd}OptionSet"
         assert actual.text is None
         children = list(actual)
         assert len(children) == 1
         assert len(children[0].attrib.keys()) == 3
-        assert children[0].attrib['Name'] == "key"
-        assert children[0].attrib['attrib1'] == "value1"
-        assert children[0].attrib['attrib2'] == "value2"
-        assert children[0].tag == \
-            "{http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd}Option"
+        assert children[0].attrib["Name"] == "key"
+        assert children[0].attrib["attrib1"] == "value1"
+        assert children[0].attrib["attrib2"] == "value2"
+        assert children[0].tag == "{http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd}Option"
         assert children[0].text == "value"
         assert str(option_set) == "{'key': 'value'}"
 
@@ -571,37 +589,31 @@ class TestOptionSet(object):
         option_set.add_option("key2", "value2")
         actual = option_set.pack()
         assert len(actual.attrib.keys()) == 1
-        assert actual.attrib['{http://www.w3.org/2003/05/soap-envelope}'
-                             'mustUnderstand'] == 'true'
-        assert actual.tag == \
-            "{http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd}OptionSet"
+        assert actual.attrib["{http://www.w3.org/2003/05/soap-envelope}mustUnderstand"] == "true"
+        assert actual.tag == "{http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd}OptionSet"
         assert actual.text is None
         children = list(actual)
         assert len(children) == 2
 
         assert len(children[0].attrib.keys()) == 1
-        assert children[0].attrib['Name'] == "key1"
-        assert children[0].tag == \
-            "{http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd}Option"
+        assert children[0].attrib["Name"] == "key1"
+        assert children[0].tag == "{http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd}Option"
         assert children[0].text == "value1"
 
         assert len(children[1].attrib.keys()) == 1
-        assert children[1].attrib['Name'] == "key2"
-        assert children[1].tag == \
-            "{http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd}Option"
+        assert children[1].attrib["Name"] == "key2"
+        assert children[1].tag == "{http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd}Option"
         assert children[1].text == "value2"
 
         assert str(option_set) == "{'key1': 'value1', 'key2': 'value2'}"
 
 
 class TestSelectorSet(object):
-
     def test_set_no_options(self):
         selector_set = SelectorSet()
         actual = selector_set.pack()
         assert len(actual.attrib.keys()) == 0
-        assert actual.tag == \
-            "{http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd}SelectorSet"
+        assert actual.tag == "{http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd}SelectorSet"
         assert actual.text is None
         assert list(actual) == []
         assert str(selector_set) == "{}"
@@ -611,35 +623,30 @@ class TestSelectorSet(object):
         selector_set.add_option("key", "value")
         actual = selector_set.pack()
         assert len(actual.attrib.keys()) == 0
-        assert actual.tag == \
-            "{http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd}SelectorSet"
+        assert actual.tag == "{http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd}SelectorSet"
         assert actual.text is None
         children = list(actual)
         assert len(children) == 1
         assert len(children[0].attrib.keys()) == 1
-        assert children[0].attrib['Name'] == "key"
-        assert children[0].tag == \
-            "{http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd}Selector"
+        assert children[0].attrib["Name"] == "key"
+        assert children[0].tag == "{http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd}Selector"
         assert children[0].text == "value"
         assert str(selector_set) == "{'key': 'value'}"
 
     def test_set_one_option_with_attributes(self):
         selector_set = SelectorSet()
-        selector_set.add_option("key", "value",
-                                {"attrib1": "value1", "attrib2": "value2"})
+        selector_set.add_option("key", "value", {"attrib1": "value1", "attrib2": "value2"})
         actual = selector_set.pack()
         assert len(actual.attrib.keys()) == 0
-        assert actual.tag == \
-            "{http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd}SelectorSet"
+        assert actual.tag == "{http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd}SelectorSet"
         assert actual.text is None
         children = list(actual)
         assert len(children) == 1
         assert len(children[0].attrib.keys()) == 3
-        assert children[0].attrib['Name'] == "key"
-        assert children[0].attrib['attrib1'] == "value1"
-        assert children[0].attrib['attrib2'] == "value2"
-        assert children[0].tag == \
-            "{http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd}Selector"
+        assert children[0].attrib["Name"] == "key"
+        assert children[0].attrib["attrib1"] == "value1"
+        assert children[0].attrib["attrib2"] == "value2"
+        assert children[0].tag == "{http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd}Selector"
         assert children[0].text == "value"
         assert str(selector_set) == "{'key': 'value'}"
 
@@ -649,76 +656,70 @@ class TestSelectorSet(object):
         selector_set.add_option("key2", "value2")
         actual = selector_set.pack()
         assert len(actual.attrib.keys()) == 0
-        assert actual.tag == \
-            "{http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd}SelectorSet"
+        assert actual.tag == "{http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd}SelectorSet"
         assert actual.text is None
         children = list(actual)
         assert len(children) == 2
 
         assert len(children[0].attrib.keys()) == 1
-        assert children[0].attrib['Name'] == "key1"
-        assert children[0].tag == \
-            "{http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd}Selector"
+        assert children[0].attrib["Name"] == "key1"
+        assert children[0].tag == "{http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd}Selector"
         assert children[0].text == "value1"
 
         assert len(children[1].attrib.keys()) == 1
-        assert children[1].attrib['Name'] == "key2"
-        assert children[1].tag == \
-            "{http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd}Selector"
+        assert children[1].attrib["Name"] == "key2"
+        assert children[1].tag == "{http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd}Selector"
         assert children[1].text == "value2"
 
         assert str(selector_set) == "{'key1': 'value1', 'key2': 'value2'}"
 
 
-
 class TestTransportHTTP(object):
-
     def test_not_supported_auth(self):
         with pytest.raises(ValueError) as err:
             _TransportHTTP("", "", auth="fake")
-        assert str(err.value) == \
-            "The specified auth 'fake' is not supported, please select one " \
+        assert (
+            str(err.value) == "The specified auth 'fake' is not supported, please select one "
             "of 'basic, certificate, credssp, kerberos, negotiate, ntlm'"
+        )
 
     def test_invalid_encryption_value(self):
         with pytest.raises(ValueError) as err:
             _TransportHTTP("", "", encryption="fake")
-        assert str(err.value) == \
-            "The encryption value 'fake' must be auto, always, or never"
+        assert str(err.value) == "The encryption value 'fake' must be auto, always, or never"
 
     def test_encryption_always_not_valid_auth_ssl(self):
         with pytest.raises(ValueError) as err:
             _TransportHTTP("", "", auth="basic", encryption="always", ssl=True)
-        assert str(err.value) == \
-            "Cannot use message encryption with auth 'basic', either set " \
-            "encryption='auto' or use one of the following auth providers: " \
+        assert (
+            str(err.value) == "Cannot use message encryption with auth 'basic', either set "
+            "encryption='auto' or use one of the following auth providers: "
             "credssp, kerberos, negotiate, ntlm"
+        )
 
     def test_encryption_auto_not_valid_auth_no_ssl(self):
         with pytest.raises(ValueError) as err:
             _TransportHTTP("", "", auth="basic", encryption="auto", ssl=False)
-        assert str(err.value) == \
-            "Cannot use message encryption with auth 'basic', either set " \
-            "encryption='never', use ssl=True or use one of the following " \
+        assert (
+            str(err.value) == "Cannot use message encryption with auth 'basic', either set "
+            "encryption='never', use ssl=True or use one of the following "
             "auth providers: credssp, kerberos, negotiate, ntlm"
+        )
 
     def test_build_basic_no_username(self):
         transport = _TransportHTTP("")
         with pytest.raises(ValueError) as err:
             transport._build_auth_basic(None)
-        assert str(err.value) == \
-            "For basic auth, the username must be specified"
+        assert str(err.value) == "For basic auth, the username must be specified"
 
     def test_build_basic_no_password(self):
         transport = _TransportHTTP("", username="user")
         with pytest.raises(ValueError) as err:
             transport._build_auth_basic(None)
-        assert str(err.value) == \
-            "For basic auth, the password must be specified"
+        assert str(err.value) == "For basic auth, the password must be specified"
 
     def test_build_basic(self):
-        transport = _TransportHTTP("", username="user", password="pass",
-                                   auth="basic")
+        transport = _TransportHTTP("", username="user", password="pass", auth="basic")
         session = transport._build_session()
         assert transport.encryption is None
         assert isinstance(session.auth, requests.auth.HTTPBasicAuth)
@@ -729,36 +730,33 @@ class TestTransportHTTP(object):
         transport = _TransportHTTP("")
         with pytest.raises(ValueError) as err:
             transport._build_auth_certificate(None)
-        assert str(err.value) == \
-            "For certificate auth, the path to the certificate key pem file " \
+        assert (
+            str(err.value) == "For certificate auth, the path to the certificate key pem file "
             "must be specified with certificate_key_pem"
+        )
 
     def test_build_certificate_no_pem(self):
         transport = _TransportHTTP("", certificate_key_pem="path")
         with pytest.raises(ValueError) as err:
             transport._build_auth_certificate(None)
-        assert str(err.value) == \
-            "For certificate auth, the path to the certificate pem file " \
+        assert (
+            str(err.value) == "For certificate auth, the path to the certificate pem file "
             "must be specified with certificate_pem"
+        )
 
     def test_build_certificate_not_ssl(self):
-        transport = _TransportHTTP("", certificate_key_pem="path",
-                                   certificate_pem="path", ssl=False)
+        transport = _TransportHTTP("", certificate_key_pem="path", certificate_pem="path", ssl=False)
         with pytest.raises(ValueError) as err:
             transport._build_auth_certificate(None)
         assert str(err.value) == "For certificate auth, SSL must be used"
 
     def test_build_certificate(self):
-        transport = _TransportHTTP("", auth="certificate",
-                                   certificate_key_pem="key_pem",
-                                   certificate_pem="pem")
+        transport = _TransportHTTP("", auth="certificate", certificate_key_pem="key_pem", certificate_pem="pem")
         session = transport._build_session()
         assert transport.encryption is None
         assert session.auth is None
         assert session.cert == ("pem", "key_pem")
-        assert session.headers['Authorization'] == \
-            "http://schemas.dmtf.org/wbem/wsman/1/wsman/secprofile/" \
-            "https/mutual"
+        assert session.headers["Authorization"] == "http://schemas.dmtf.org/wbem/wsman/1/wsman/secprofile/https/mutual"
 
     @pytest.mark.skipif(
         requests_credssp,
@@ -779,43 +777,44 @@ class TestTransportHTTP(object):
         transport = _TransportHTTP("")
         with pytest.raises(ValueError) as err:
             transport._build_auth_credssp(None)
-        assert str(err.value) == \
-            "For credssp auth, the username must be specified"
+        assert str(err.value) == "For credssp auth, the username must be specified"
 
     def test_build_credssp_no_password(self):
         transport = _TransportHTTP("", username="user")
         with pytest.raises(ValueError) as err:
             transport._build_auth_credssp(None)
-        assert str(err.value) == \
-            "For credssp auth, the password must be specified"
+        assert str(err.value) == "For credssp auth, the password must be specified"
 
     def test_build_credssp_no_kwargs(self):
         credssp = pytest.importorskip("requests_credssp")
 
-        transport = _TransportHTTP("", username="user", password="pass",
-                                   auth="credssp")
+        transport = _TransportHTTP("", username="user", password="pass", auth="credssp")
         session = transport._build_session()
         assert isinstance(session.auth, credssp.HttpCredSSPAuth)
         assert session.auth.disable_tlsv1_2 is False
         assert session.auth.minimum_version == 2
-        assert session.auth.password == 'pass'
-        assert session.auth.username == 'user'
+        assert session.auth.password == "pass"
+        assert session.auth.username == "user"
 
     def test_build_credssp_with_kwargs(self):
         credssp = pytest.importorskip("requests_credssp")
 
-        transport = _TransportHTTP("", username="user", password="pass",
-                                   auth="credssp",
-                                   credssp_auth_mechanism="kerberos",
-                                   credssp_disable_tlsv1_2=True,
-                                   credssp_minimum_version=5)
+        transport = _TransportHTTP(
+            "",
+            username="user",
+            password="pass",
+            auth="credssp",
+            credssp_auth_mechanism="kerberos",
+            credssp_disable_tlsv1_2=True,
+            credssp_minimum_version=5,
+        )
 
         session = transport._build_session()
         assert isinstance(session.auth, credssp.HttpCredSSPAuth)
         assert session.auth.disable_tlsv1_2 is True
         assert session.auth.minimum_version == 5
-        assert session.auth.password == 'pass'
-        assert session.auth.username == 'user'
+        assert session.auth.password == "pass"
+        assert session.auth.username == "user"
 
     def test_build_kerberos(self):
         transport = _TransportHTTP("", auth="kerberos")
@@ -826,17 +825,22 @@ class TestTransportHTTP(object):
         assert session.auth.hostname_override is None
         assert session.auth.password is None
         assert session.auth.send_cbt is True
-        assert session.auth.service == 'WSMAN'
+        assert session.auth.service == "WSMAN"
         assert session.auth.username is None
         assert session.auth.wrap_required is False
 
     def test_build_kerberos_with_kwargs(self):
-        transport = _TransportHTTP("", auth="kerberos", username="user",
-                                   ssl=False, password="pass",
-                                   negotiate_delegate=True,
-                                   negotiate_hostname_override="host",
-                                   negotiate_send_cbt=False,
-                                   negotiate_service="HTTP")
+        transport = _TransportHTTP(
+            "",
+            auth="kerberos",
+            username="user",
+            ssl=False,
+            password="pass",
+            negotiate_delegate=True,
+            negotiate_hostname_override="host",
+            negotiate_send_cbt=False,
+            negotiate_service="HTTP",
+        )
         session = transport._build_session()
         assert isinstance(session.auth, HTTPNegotiateAuth)
         assert session.auth.auth_provider == "kerberos"
@@ -844,7 +848,7 @@ class TestTransportHTTP(object):
         assert session.auth.hostname_override == "host"
         assert session.auth.password == "pass"
         assert session.auth.send_cbt is False
-        assert session.auth.service == 'HTTP'
+        assert session.auth.service == "HTTP"
         assert session.auth.username == "user"
         assert session.auth.wrap_required is True
 
@@ -857,17 +861,22 @@ class TestTransportHTTP(object):
         assert session.auth.hostname_override is None
         assert session.auth.password is None
         assert session.auth.send_cbt is True
-        assert session.auth.service == 'WSMAN'
+        assert session.auth.service == "WSMAN"
         assert session.auth.username is None
         assert session.auth.wrap_required is False
 
     def test_build_negotiate_with_kwargs(self):
-        transport = _TransportHTTP("", auth="negotiate", username="user",
-                                   ssl=False, password="pass",
-                                   negotiate_delegate=True,
-                                   negotiate_hostname_override="host",
-                                   negotiate_send_cbt=False,
-                                   negotiate_service="HTTP")
+        transport = _TransportHTTP(
+            "",
+            auth="negotiate",
+            username="user",
+            ssl=False,
+            password="pass",
+            negotiate_delegate=True,
+            negotiate_hostname_override="host",
+            negotiate_send_cbt=False,
+            negotiate_service="HTTP",
+        )
         session = transport._build_session()
         assert isinstance(session.auth, HTTPNegotiateAuth)
         assert session.auth.auth_provider == "negotiate"
@@ -875,7 +884,7 @@ class TestTransportHTTP(object):
         assert session.auth.hostname_override == "host"
         assert session.auth.password == "pass"
         assert session.auth.send_cbt is False
-        assert session.auth.service == 'HTTP'
+        assert session.auth.service == "HTTP"
         assert session.auth.username == "user"
         assert session.auth.wrap_required is True
 
@@ -888,18 +897,23 @@ class TestTransportHTTP(object):
         assert session.auth.hostname_override is None
         assert session.auth.password is None
         assert session.auth.send_cbt is True
-        assert session.auth.service == 'WSMAN'
+        assert session.auth.service == "WSMAN"
         assert session.auth.username is None
         assert session.auth.wrap_required is False
 
     def test_build_ntlm_with_kwargs(self):
-        transport = _TransportHTTP("", auth="ntlm", username="user",
-                                   ssl=False, password="pass",
-                                   negotiate_delegate=True,
-                                   negotiate_hostname_override="host",
-                                   negotiate_send_cbt=False,
-                                   negotiate_service="HTTP",
-                                   cert_validation=False)
+        transport = _TransportHTTP(
+            "",
+            auth="ntlm",
+            username="user",
+            ssl=False,
+            password="pass",
+            negotiate_delegate=True,
+            negotiate_hostname_override="host",
+            negotiate_send_cbt=False,
+            negotiate_service="HTTP",
+            cert_validation=False,
+        )
         session = transport._build_session()
         assert isinstance(session.auth, HTTPNegotiateAuth)
         assert session.auth.auth_provider == "ntlm"
@@ -907,18 +921,18 @@ class TestTransportHTTP(object):
         assert session.auth.hostname_override == "host"
         assert session.auth.password == "pass"
         assert session.auth.send_cbt is False
-        assert session.auth.service == 'HTTP'
+        assert session.auth.service == "HTTP"
         assert session.auth.username == "user"
         assert session.auth.wrap_required is True
 
     def test_build_session_default(self):
         transport = _TransportHTTP("")
         session = transport._build_session()
-        assert session.headers['User-Agent'] == "Python PSRP Client"
+        assert session.headers["User-Agent"] == "Python PSRP Client"
         assert session.trust_env is True
         assert isinstance(session.auth, HTTPNegotiateAuth)
-        assert 'http' not in session.proxies
-        assert 'https' not in session.proxies
+        assert "http" not in session.proxies
+        assert "https" not in session.proxies
         assert session.verify is True
 
     def test_build_session_cert_validate(self):
@@ -928,21 +942,21 @@ class TestTransportHTTP(object):
 
     def test_build_session_cert_validate_env(self):
         transport = _TransportHTTP("", cert_validation=True)
-        os.environ['REQUESTS_CA_BUNDLE'] = 'path_to_REQUESTS_CA_CERT'
+        os.environ["REQUESTS_CA_BUNDLE"] = "path_to_REQUESTS_CA_CERT"
         try:
             session = transport._build_session()
         finally:
-            del os.environ['REQUESTS_CA_BUNDLE']
-        assert session.verify == 'path_to_REQUESTS_CA_CERT'
+            del os.environ["REQUESTS_CA_BUNDLE"]
+        assert session.verify == "path_to_REQUESTS_CA_CERT"
 
     def test_build_session_cert_validate_path_override_env(self):
         transport = _TransportHTTP("", cert_validation="kwarg_path")
-        os.environ['REQUESTS_CA_BUNDLE'] = 'path_to_REQUESTS_CA_CERT'
+        os.environ["REQUESTS_CA_BUNDLE"] = "path_to_REQUESTS_CA_CERT"
         try:
             session = transport._build_session()
         finally:
-            del os.environ['REQUESTS_CA_BUNDLE']
-        assert session.verify == 'kwarg_path'
+            del os.environ["REQUESTS_CA_BUNDLE"]
+        assert session.verify == "kwarg_path"
 
     def test_build_session_cert_no_validate(self):
         transport = _TransportHTTP("", cert_validation=False)
@@ -951,70 +965,68 @@ class TestTransportHTTP(object):
 
     def test_build_session_cert_no_validate_override_env(self):
         transport = _TransportHTTP("", cert_validation=False)
-        os.environ['REQUESTS_CA_BUNDLE'] = 'path_to_REQUESTS_CA_CERT'
+        os.environ["REQUESTS_CA_BUNDLE"] = "path_to_REQUESTS_CA_CERT"
         try:
             session = transport._build_session()
         finally:
-            del os.environ['REQUESTS_CA_BUNDLE']
+            del os.environ["REQUESTS_CA_BUNDLE"]
         assert session.verify is False
 
     def test_build_session_proxies_default(self):
         transport = _TransportHTTP("server")
         session = transport._build_session()
-        assert 'http' not in session.proxies
-        assert 'https' not in session.proxies
+        assert "http" not in session.proxies
+        assert "https" not in session.proxies
 
     def test_build_session_proxies_env(self):
         transport = _TransportHTTP("server")
-        os.environ['https_proxy'] = "https://envproxy"
+        os.environ["https_proxy"] = "https://envproxy"
         try:
             session = transport._build_session()
         finally:
-            del os.environ['https_proxy']
-        assert 'http' not in session.proxies
+            del os.environ["https_proxy"]
+        assert "http" not in session.proxies
         assert session.proxies["https"] == "https://envproxy"
 
     def test_build_session_proxies_kwarg(self):
         transport = _TransportHTTP("server", proxy="https://kwargproxy")
         session = transport._build_session()
-        assert 'http' not in session.proxies
+        assert "http" not in session.proxies
         assert session.proxies["https"] == "https://kwargproxy"
 
     def test_build_session_proxies_kwarg_non_ssl(self):
-        transport = _TransportHTTP("server", proxy="http://kwargproxy",
-                                   ssl=False)
+        transport = _TransportHTTP("server", proxy="http://kwargproxy", ssl=False)
         session = transport._build_session()
         assert session.proxies["http"] == "http://kwargproxy"
-        assert 'https' not in session.proxies
+        assert "https" not in session.proxies
 
     def test_build_session_proxies_env_kwarg_override(self):
         transport = _TransportHTTP("server", proxy="https://kwargproxy")
-        os.environ['https_proxy'] = "https://envproxy"
+        os.environ["https_proxy"] = "https://envproxy"
         try:
             session = transport._build_session()
         finally:
-            del os.environ['https_proxy']
-        assert 'http' not in session.proxies
-        assert session.proxies['https'] == "https://kwargproxy"
+            del os.environ["https_proxy"]
+        assert "http" not in session.proxies
+        assert session.proxies["https"] == "https://kwargproxy"
 
     def test_build_session_proxies_env_no_proxy_override(self):
         transport = _TransportHTTP("server", no_proxy=True)
-        os.environ['https_proxy'] = "https://envproxy"
+        os.environ["https_proxy"] = "https://envproxy"
         try:
             session = transport._build_session()
         finally:
-            del os.environ['https_proxy']
-        assert session.proxies == {'https': False}
+            del os.environ["https_proxy"]
+        assert session.proxies == {"https": False}
 
     def test_build_session_proxies_kwarg_ignore_no_proxy(self):
-        transport = _TransportHTTP("server", proxy="https://kwargproxy",
-                                   no_proxy=True)
+        transport = _TransportHTTP("server", proxy="https://kwargproxy", no_proxy=True)
         session = transport._build_session()
-        assert 'http' not in session.proxies
-        assert session.proxies['https'] == "https://kwargproxy"
+        assert "http" not in session.proxies
+        assert session.proxies["https"] == "https://kwargproxy"
 
-    def test_send_without_encryption(self, monkeypatch):
-        send_mock = MagicMock()
+    def test_send_without_encryption(self, monkeypatch, mocker):
+        send_mock = mocker.MagicMock()
 
         monkeypatch.setattr(_TransportHTTP, "_send_request", send_mock)
 
@@ -1026,17 +1038,17 @@ class TestTransportHTTP(object):
 
         assert actual_request.body == b"message"
         assert actual_request.url == "https://server:5986/wsman"
-        assert actual_request.headers['content-type'] == "application/soap+xml;charset=UTF-8"
+        assert actual_request.headers["content-type"] == "application/soap+xml;charset=UTF-8"
 
-    def test_send_with_encryption(self, monkeypatch):
-        send_mock = MagicMock()
+    def test_send_with_encryption(self, monkeypatch, mocker):
+        send_mock = mocker.MagicMock()
 
         def send_request(self, *args, **kwargs):
-            self.session.auth.contexts['server'] = MagicMock()
+            self.session.auth.contexts["server"] = mocker.MagicMock()
 
             return send_mock(*args, **kwargs)
 
-        wrap_mock = MagicMock()
+        wrap_mock = mocker.MagicMock()
         wrap_mock.return_value = "multipart/encrypted", b"wrapped"
 
         monkeypatch.setattr(_TransportHTTP, "_send_request", send_request)
@@ -1055,28 +1067,30 @@ class TestTransportHTTP(object):
         assert actual_request1.url == "http://server:5985/wsman"
 
         assert actual_request2.body == b"wrapped"
-        assert actual_request2.headers['content-type'] == \
-            'multipart/encrypted;protocol="application/' \
+        assert (
+            actual_request2.headers["content-type"] == 'multipart/encrypted;protocol="application/'
             'HTTP-SPNEGO-session-encrypted";boundary="Encrypted Boundary"'
+        )
         assert actual_request2.url == "http://server:5985/wsman"
 
         assert actual_request3.body == b"wrapped"
-        assert actual_request3.headers['content-type'] == \
-            'multipart/encrypted;protocol="application/' \
+        assert (
+            actual_request3.headers["content-type"] == 'multipart/encrypted;protocol="application/'
             'HTTP-SPNEGO-session-encrypted";boundary="Encrypted Boundary"'
+        )
         assert actual_request3.url == "http://server:5985/wsman"
 
         assert wrap_mock.call_count == 2
         assert wrap_mock.call_args_list[0][0][0] == b"message"
         assert wrap_mock.call_args_list[1][0][0] == b"message 2"
 
-    def test_send_default(self, monkeypatch):
+    def test_send_default(self, monkeypatch, mocker):
         response = requests.Response()
         response.status_code = 200
         response._content = b"content"
-        response.headers['content-type'] = "application/soap+xml;charset=UTF-8"
+        response.headers["content-type"] = "application/soap+xml;charset=UTF-8"
 
-        send_mock = MagicMock()
+        send_mock = mocker.MagicMock()
         send_mock.return_value = response
 
         monkeypatch.setattr(requests.Session, "send", send_mock)
@@ -1084,22 +1098,22 @@ class TestTransportHTTP(object):
         transport = _TransportHTTP("server", ssl=True)
         session = transport._build_session()
         transport.session = session
-        request = requests.Request('POST', transport.endpoint, data=b"data")
+        request = requests.Request("POST", transport.endpoint, data=b"data")
         prep_request = session.prepare_request(request)
 
         actual = transport._send_request(prep_request)
         assert actual == b"content"
         assert send_mock.call_count == 1
         assert send_mock.call_args[0] == (prep_request,)
-        assert send_mock.call_args[1]['timeout'] == (30, 30)
+        assert send_mock.call_args[1]["timeout"] == (30, 30)
 
-    def test_send_timeout_kwargs(self, monkeypatch):
+    def test_send_timeout_kwargs(self, monkeypatch, mocker):
         response = requests.Response()
         response.status_code = 200
         response._content = b"content"
-        response.headers['content-type'] = "application/soap+xml;charset=UTF-8"
+        response.headers["content-type"] = "application/soap+xml;charset=UTF-8"
 
-        send_mock = MagicMock()
+        send_mock = mocker.MagicMock()
         send_mock.return_value = response
 
         monkeypatch.setattr(requests.Session, "send", send_mock)
@@ -1107,20 +1121,20 @@ class TestTransportHTTP(object):
         transport = _TransportHTTP("server", ssl=True, connection_timeout=20, read_timeout=25)
         session = transport._build_session()
         transport.session = session
-        request = requests.Request('POST', transport.endpoint, data=b"data")
+        request = requests.Request("POST", transport.endpoint, data=b"data")
         prep_request = session.prepare_request(request)
 
         actual = transport._send_request(prep_request)
         assert actual == b"content"
         assert send_mock.call_count == 1
         assert send_mock.call_args[0] == (prep_request,)
-        assert send_mock.call_args[1]['timeout'] == (20, 25)
+        assert send_mock.call_args[1]["timeout"] == (20, 25)
 
-    def test_send_auth_error(self, monkeypatch):
+    def test_send_auth_error(self, monkeypatch, mocker):
         response = requests.Response()
         response.status_code = 401
 
-        send_mock = MagicMock()
+        send_mock = mocker.MagicMock()
         send_mock.return_value = response
 
         monkeypatch.setattr(requests.Session, "send", send_mock)
@@ -1128,20 +1142,19 @@ class TestTransportHTTP(object):
         transport = _TransportHTTP("server", ssl=True)
         session = transport._build_session()
         transport.session = session
-        request = requests.Request('POST', transport.endpoint, data=b"data")
+        request = requests.Request("POST", transport.endpoint, data=b"data")
         prep_request = session.prepare_request(request)
 
         with pytest.raises(AuthenticationError) as err:
             transport._send_request(prep_request)
-        assert str(err.value) == "Failed to authenticate the user None with " \
-                                 "negotiate"
+        assert str(err.value) == "Failed to authenticate the user None with negotiate"
 
-    def test_send_winrm_error_blank(self, monkeypatch):
+    def test_send_winrm_error_blank(self, monkeypatch, mocker):
         response = requests.Response()
         response.status_code = 500
         response._content = b""
 
-        send_mock = MagicMock()
+        send_mock = mocker.MagicMock()
         send_mock.return_value = response
 
         monkeypatch.setattr(requests.Session, "send", send_mock)
@@ -1149,23 +1162,22 @@ class TestTransportHTTP(object):
         transport = _TransportHTTP("server", ssl=True)
         session = transport._build_session()
         transport.session = session
-        request = requests.Request('POST', transport.endpoint, data=b"data")
+        request = requests.Request("POST", transport.endpoint, data=b"data")
         prep_request = session.prepare_request(request)
 
         with pytest.raises(WinRMTransportError) as err:
             transport._send_request(prep_request)
-        assert str(err.value) == "Bad HTTP response returned from the " \
-                                 "server. Code: 500, Content: ''"
+        assert str(err.value) == "Bad HTTP response returned from the server. Code: 500, Content: ''"
         assert err.value.code == 500
-        assert err.value.protocol == 'http'
-        assert err.value.response_text == ''
+        assert err.value.protocol == "http"
+        assert err.value.response_text == ""
 
-    def test_send_winrm_error_content(self, monkeypatch):
+    def test_send_winrm_error_content(self, monkeypatch, mocker):
         response = requests.Response()
         response.status_code = 500
         response._content = b"error msg"
 
-        send_mock = MagicMock()
+        send_mock = mocker.MagicMock()
         send_mock.return_value = response
 
         monkeypatch.setattr(requests.Session, "send", send_mock)
@@ -1173,28 +1185,27 @@ class TestTransportHTTP(object):
         transport = _TransportHTTP("server", ssl=True)
         session = transport._build_session()
         transport.session = session
-        request = requests.Request('POST', transport.endpoint, data=b"data")
+        request = requests.Request("POST", transport.endpoint, data=b"data")
         prep_request = session.prepare_request(request)
 
         with pytest.raises(WinRMTransportError) as err:
             transport._send_request(prep_request)
-        assert str(err.value) == "Bad HTTP response returned from the " \
-                                 "server. Code: 500, Content: 'error msg'"
+        assert str(err.value) == "Bad HTTP response returned from the server. Code: 500, Content: 'error msg'"
         assert err.value.code == 500
-        assert err.value.protocol == 'http'
-        assert err.value.response_text == 'error msg'
+        assert err.value.protocol == "http"
+        assert err.value.response_text == "error msg"
 
-    def test_send_winrm_encrypted_single(self, monkeypatch):
+    def test_send_winrm_encrypted_single(self, monkeypatch, mocker):
         response = requests.Response()
         response.status_code = 200
         response._content = b"content"
-        response.headers['content-type'] = \
-            'multipart/encrypted;protocol="application/HTTP-SPNEGO-session-' \
-            'encrypted";boundary="Encrypted Boundary"'
+        response.headers["content-type"] = (
+            'multipart/encrypted;protocol="application/HTTP-SPNEGO-session-' 'encrypted";boundary="Encrypted Boundary"'
+        )
 
-        send_mock = MagicMock()
+        send_mock = mocker.MagicMock()
         send_mock.return_value = response
-        unwrap_mock = MagicMock()
+        unwrap_mock = mocker.MagicMock()
         unwrap_mock.return_value = b"unwrapped content"
 
         monkeypatch.setattr(requests.Session, "send", send_mock)
@@ -1204,30 +1215,31 @@ class TestTransportHTTP(object):
         transport.encryption = WinRMEncryption(None, None)
         session = transport._build_session()
         transport.session = session
-        request = requests.Request('POST', transport.endpoint, data=b"data")
+        request = requests.Request("POST", transport.endpoint, data=b"data")
         prep_request = session.prepare_request(request)
 
         actual = transport._send_request(prep_request)
         assert actual == b"unwrapped content"
         assert send_mock.call_count == 1
         assert send_mock.call_args[0] == (prep_request,)
-        assert send_mock.call_args[1]['timeout'] == (30, 30)
+        assert send_mock.call_args[1]["timeout"] == (30, 30)
 
         assert unwrap_mock.call_count == 1
         assert unwrap_mock.call_args[0] == (b"content", "Encrypted Boundary")
         assert unwrap_mock.call_args[1] == {}
 
-    def test_send_winrm_encrypted_multiple(self, monkeypatch):
+    def test_send_winrm_encrypted_multiple(self, monkeypatch, mocker):
         response = requests.Response()
         response.status_code = 200
         response._content = b"content"
-        response.headers['content-type'] = \
-            'multipart/x-multi-encrypted;protocol="application/HTTP-CredSSP-' \
+        response.headers["content-type"] = (
+            'multipart/x-multi-encrypted;protocol="application/HTTP-CredSSP-'
             'session-encrypted";boundary="Encrypted Boundary"'
+        )
 
-        send_mock = MagicMock()
+        send_mock = mocker.MagicMock()
         send_mock.return_value = response
-        unwrap_mock = MagicMock()
+        unwrap_mock = mocker.MagicMock()
         unwrap_mock.return_value = b"unwrapped content"
 
         monkeypatch.setattr(requests.Session, "send", send_mock)
@@ -1237,35 +1249,45 @@ class TestTransportHTTP(object):
         transport.encryption = WinRMEncryption(None, None)
         session = transport._build_session()
         transport.session = session
-        request = requests.Request('POST', transport.endpoint, data=b"data")
+        request = requests.Request("POST", transport.endpoint, data=b"data")
         prep_request = session.prepare_request(request)
 
         actual = transport._send_request(prep_request)
         assert actual == b"unwrapped content"
         assert send_mock.call_count == 1
         assert send_mock.call_args[0] == (prep_request,)
-        assert send_mock.call_args[1]['timeout'] == (30, 30)
+        assert send_mock.call_args[1]["timeout"] == (30, 30)
 
         assert unwrap_mock.call_count == 1
         assert unwrap_mock.call_args[0] == (b"content", "Encrypted Boundary")
         assert unwrap_mock.call_args[1] == {}
 
-    @pytest.mark.parametrize('ssl, server, port, path, expected', [
-        [True, 'server', 5986, 'wsman', 'https://server:5986/wsman'],
-        [False, 'server', 5985, 'wsman', 'http://server:5985/wsman'],
-        [False, 'server', 5985, 'iis-wsman', 'http://server:5985/iis-wsman'],
-        [True, '127.0.0.1', 443, 'wsman', 'https://127.0.0.1:443/wsman'],
-        [False, '2001:0db8:0a0b:12f0:0000:0000:0000:0001', 80, 'path',
-         'http://[2001:db8:a0b:12f0::1]:80/path'],
-        [False, '2001:db8:a0b:12f0::1', 80, 'path',
-         'http://[2001:db8:a0b:12f0::1]:80/path'],
-        [False, '2001:0db8:0a0b:12f0:0001:0001:0001:0001', 5985, 'wsman',
-         'http://[2001:db8:a0b:12f0:1:1:1:1]:5985/wsman'],
-        [False, 'FE80::0202:B3FF:FE1E:8329', 5985, 'wsman',
-         'http://[fe80::202:b3ff:fe1e:8329]:5985/wsman'],
-        [True, '[2001:0db8:0a0b:12f0:0000:0000:0000:0001]', 5986, 'wsman',
-         'https://[2001:0db8:0a0b:12f0:0000:0000:0000:0001]:5986/wsman'],
-    ])
+    @pytest.mark.parametrize(
+        "ssl, server, port, path, expected",
+        [
+            [True, "server", 5986, "wsman", "https://server:5986/wsman"],
+            [False, "server", 5985, "wsman", "http://server:5985/wsman"],
+            [False, "server", 5985, "iis-wsman", "http://server:5985/iis-wsman"],
+            [True, "127.0.0.1", 443, "wsman", "https://127.0.0.1:443/wsman"],
+            [False, "2001:0db8:0a0b:12f0:0000:0000:0000:0001", 80, "path", "http://[2001:db8:a0b:12f0::1]:80/path"],
+            [False, "2001:db8:a0b:12f0::1", 80, "path", "http://[2001:db8:a0b:12f0::1]:80/path"],
+            [
+                False,
+                "2001:0db8:0a0b:12f0:0001:0001:0001:0001",
+                5985,
+                "wsman",
+                "http://[2001:db8:a0b:12f0:1:1:1:1]:5985/wsman",
+            ],
+            [False, "FE80::0202:B3FF:FE1E:8329", 5985, "wsman", "http://[fe80::202:b3ff:fe1e:8329]:5985/wsman"],
+            [
+                True,
+                "[2001:0db8:0a0b:12f0:0000:0000:0000:0001]",
+                5986,
+                "wsman",
+                "https://[2001:0db8:0a0b:12f0:0000:0000:0000:0001]:5986/wsman",
+            ],
+        ],
+    )
     def test_endpoint_forms(self, ssl, server, port, path, expected):
         actual = _TransportHTTP._create_endpoint(ssl, server, port, path)
         assert actual == expected


### PR DESCRIPTION
Changes the sole linting tool from pycodestyle to a combination of
black, isort, and mypy. The isort tool makes it simpler to manage
imports in a common manner and black's auto formatting is very helpful
in ensuring a consistent codebase.

Mypy is enabled in a limited fashion to start introducting type
annotations to the code base. The py.typed is also included in the sdist
and wheel for users of this library to pick up for type validation.

Finally these are also added to a pre-commit hook that helps developers
of this library more easily run the sanity checks if they wish to do so.