### PR TITLE
Prepare for 0.8.0rc1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## FUTURE - TBD
+## 0.8.0 - TBD
 
 * The `CommandParameter` class now uses named keyword arguments
 * The `cmd` parameter for `Command` class is now a positional argument

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pypsrp
-version = 0.8.0
+version = 0.8.0rc1
 url = https://github.com/jborean93/pypsrp
 author = Jordan Borean
 author_email = jborean93@gmail.com


### PR DESCRIPTION
Preparing for the next release - using a pre-release as the build process has changed quite dramatically.