### PR TITLE
Fix Exchange Connection Problems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 * Fix up certificate authentication over TLS 1.3 connections - Python 3.8 only
 * Bump minimum Python version to 3.7
 * Cache Kerberos credentials to speed up re-authentication when starting a new WSMan connection on another thread
+* Fix deadlock when receiving certain WSManFault errors outside of a close operation
+* Fix invalid selector error when connecting to Exchange Online by re-using proper cookies
+* Fix connection info URI builder when targeting the default HTTP and HTTPS port 80/443
 
 ## 1.0.0b1 - 2022-05-27
 

--- a/tests/tests_psrp/test_io_wsman.py
+++ b/tests/tests_psrp/test_io_wsman.py
@@ -189,6 +189,7 @@ def test_connection_with_cert_auth(keypair: pathlib.Path) -> None:
 
     assert headers == {
         "Accept-Encoding": "identity",
+        "Content-Type": "application/soap+xml;charset=UTF-8",
         "User-Agent": "Python PSRP Client",
         "Authorization": "http://schemas.dmtf.org/wbem/wsman/1/wsman/secprofile/https/mutual",
     }
@@ -221,6 +222,7 @@ def test_connection_with_cert_auth_separate_key(keypair: pathlib.Path, tmpdir: p
 
     assert headers == {
         "Accept-Encoding": "identity",
+        "Content-Type": "application/soap+xml;charset=UTF-8",
         "User-Agent": "Python PSRP Client",
         "Authorization": "http://schemas.dmtf.org/wbem/wsman/1/wsman/secprofile/https/mutual",
     }
@@ -265,6 +267,7 @@ def test_connection_with_cert_auth_separate_password_protected_key(
 
     assert headers == {
         "Accept-Encoding": "identity",
+        "Content-Type": "application/soap+xml;charset=UTF-8",
         "User-Agent": "Python PSRP Client",
         "Authorization": "http://schemas.dmtf.org/wbem/wsman/1/wsman/secprofile/https/mutual",
     }


### PR DESCRIPTION
Fixes a few problems when connecting to Exchange based PSRemoting endpoints.

Fix connection uri builder when targeting port 80 or 443 for an Exchange based endpoint.

Reuse cookies returned by an Exchange Online endpoint. This fixes an invalid selector message.

Fixes a deadlock when the first receive task for a WSMan connection fails with invalid selectors. The error will now be properly reported to the caller rather than hanging indefinitely.

Fixes: https://github.com/jborean93/pypsrp/issues/157