### PR TITLE
Add overwrite protection when uploading files

### DIFF
--- a/src/psrp/_client.py
+++ b/src/psrp/_client.py
@@ -35,6 +35,7 @@ def copy_file(
     dest: str,
     *,
     expand_variables: bool = False,
+    overwrite: bool = False,
 ) -> str:
     """Copies a file to the remote connection.
 
@@ -60,6 +61,7 @@ def copy_file(
             and relative paths are resolved from the current location of the
             connection which is based on the connection type.
         expand_variables: Expand the src and dest paths for any variables.
+        overwrite: Overwrite the destination file.
 
     Returns:
         str: The absolute path to the remote destination that the local file
@@ -94,6 +96,7 @@ def copy_file(
         ps.add_parameters(
             Path=dest,
             ExpandVariables=expand_variables,
+            Overwrite=overwrite,
         )
 
         if log.isEnabledFor(logging.DEBUG):

--- a/src/psrp/_pwsh/copy.ps1
+++ b/src/psrp/_pwsh/copy.ps1
@@ -12,7 +12,11 @@ param (
 
     [Parameter()]
     [switch]
-    $ExpandVariables
+    $ExpandVariables,
+
+    [Parameter()]
+    [switch]
+    $Overwrite
 )
 
 begin {
@@ -35,6 +39,9 @@ begin {
     $parentDir = Split-Path -Path $Path -Parent
     if (-not (Test-Path -LiteralPath $parentDir)) {
         throw "Target path directory '$parentDir' does not exist"
+    }
+    if (!$overwrite -and (Test-Path -LiteralPath $Path)) {
+        throw "Target file '$Path' already exists"
     }
 
     $bindingFlags = [System.Reflection.BindingFlags]'NonPublic, Instance'


### PR DESCRIPTION
Currently `copy_file()` will overwrite the remote file without warning. This PR adds a boolean flag that by default checks and prevents overwriting the remote file.