### PR TITLE
Add support for custom user-agent header in HTTP requests

### DIFF
--- a/src/pypsrp/wsman.py
+++ b/src/pypsrp/wsman.py
@@ -203,6 +203,10 @@ class WSMan(object):
                 building the server SPN
             negotiate_service: Override the service used when building the
                 server SPN, default='WSMAN'
+
+            # custom user-agent header
+            user_agent: The user agent to use for the HTTP requests, this
+                defaults to 'Python PSRP Client'
         """
         log.debug(
             "Initialising WSMan class with maximum envelope size of %d "
@@ -740,6 +744,7 @@ class _TransportHTTP(object):
         self.read_timeout = read_timeout
         self.reconnection_retries = reconnection_retries
         self.reconnection_backoff = reconnection_backoff
+        self.user_agent = kwargs.get("user_agent")
 
         # determine the message encryption logic
         if encryption not in ["auto", "always", "never"]:
@@ -868,7 +873,10 @@ class _TransportHTTP(object):
         self._suppress_library_warnings()
 
         session = requests.Session()
-        session.headers["User-Agent"] = "Python PSRP Client"
+        if self.user_agent:
+            session.headers["User-Agent"] = self.user_agent
+        else:
+            session.headers["User-Agent"] = "Python PSRP Client"
 
         # requests defaults to 'Accept-Encoding: gzip, default' which normally doesn't matter on vanila WinRM but for
         # Exchange endpoints hosted on IIS they actually compress it with 1 of the 2 algorithms. By explicitly setting


### PR DESCRIPTION
This pull request introduces support for configuring a custom `User-Agent` header in the `WSMan` class for HTTP requests. This change allows users to specify a custom `User-Agent` string or fallback to the default value of `'Python PSRP Client'`.

### Support for custom `User-Agent` header:

* [`src/pypsrp/wsman.py`](diffhunk://#diff-001749e23ddcebf19860c551c7bfac91a0e12fb82946496cb0301579351211d9R206-R209): Added a new `user_agent` parameter to the `__init__` method, allowing users to specify a custom `User-Agent` string.
* [`src/pypsrp/wsman.py`](diffhunk://#diff-001749e23ddcebf19860c551c7bfac91a0e12fb82946496cb0301579351211d9R747): Updated the `__init__` method to store the `user_agent` parameter in the instance.
* [`src/pypsrp/wsman.py`](diffhunk://#diff-001749e23ddcebf19860c551c7bfac91a0e12fb82946496cb0301579351211d9R876-R878): Modified the `_build_session` method to set the `User-Agent` header in the HTTP session based on the `user_agent` parameter, defaulting to `'Python PSRP Client'` if not provided.